### PR TITLE
Add support for dropping rcVersion from annotation

### DIFF
--- a/pkg/helm/annotations.go
+++ b/pkg/helm/annotations.go
@@ -1,0 +1,27 @@
+package helm
+
+import (
+	"strings"
+)
+
+// ExportAnnotation is an annotation that is modified on an export
+type ExportAnnotation interface {
+	dropRCVersion(val string) (newValWithoutRC string, updated bool)
+}
+
+// AutoInstallAnnotation corresponds to catalog.cattle.io/auto-install
+type AutoInstallAnnotation struct{}
+
+func (a *AutoInstallAnnotation) dropRCVersion(val string) (newValWithoutRC string, updated bool) {
+	if strings.HasSuffix(val, "=match") {
+		return val, false
+	}
+	newValWithoutRC = strings.SplitN(val, "-rc", 2)[0]
+	return newValWithoutRC, val != newValWithoutRC
+}
+
+var (
+	exportAnnotations = map[string]ExportAnnotation{
+		"catalog.cattle.io/auto-install": &AutoInstallAnnotation{},
+	}
+)

--- a/pkg/sync/compare.go
+++ b/pkg/sync/compare.go
@@ -114,7 +114,7 @@ func CompareGeneratedAssets(rootFs billy.Filesystem, newCharts, newAssets, origi
 				return fmt.Errorf("Expected chart version to be found at %s, but that path does not represent a directory", path)
 			}
 			packageName := filepath.Base(filepath.Dir(filepath.Dir(path)))
-			err := helm.TrimRCVersionFromHelmMetadataVersion(rootFs, path)
+			err := helm.TrimRCVersionFromHelmChart(rootFs, path)
 			if err != nil {
 				return fmt.Errorf("Encountered error when dropping rc from %s", path)
 			}


### PR DESCRIPTION
This commit adds support for dropping rcVersions from any generic set of annotations that were defined under helm/annotations.go.

Currently, this only adds support for such a use case for the annotation catalog.cattle.io/auto-install.