### PR TITLE
Switch to using scripts/version

### DIFF
--- a/templates/template/scripts/pull-scripts
+++ b/templates/template/scripts/pull-scripts
@@ -3,7 +3,7 @@ set -e
 
 cd $(dirname $0)
 
-CHARTS_BUILD_SCRIPT_VERSION=v0.0.1
+source ./version
 
 echo "Pulling in charts-build-scripts version ${CHARTS_BUILD_SCRIPT_VERSION}"
 

--- a/templates/template/scripts/version
+++ b/templates/template/scripts/version
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+CHARTS_BUILD_SCRIPT_VERSION=v0.0.3


### PR DESCRIPTION
This commit ensures that a `make docs` doesn't result in overriding the scripts version.

Doesn't cause any actual changes to the code.