### PR TITLE
Support doNotReleasePackage

### DIFF
--- a/pkg/charts/package.go
+++ b/pkg/charts/package.go
@@ -25,6 +25,8 @@ type Package struct {
 	ReleaseCandidateVersion int `yaml:"releaseCandidateVersion"`
 	// AdditionalCharts are other charts that should be packaged together with this
 	AdditionalCharts []AdditionalChart `yaml:"additionalCharts,omitempty"`
+	// DoNotRelease represents a boolean flag that indicates a package should not be tracked in make charts
+	DoNotRelease bool `yaml:"doNotRelease,omitempty"`
 
 	// fs is a filesystem rooted at the package
 	fs billy.Filesystem
@@ -86,6 +88,10 @@ func (p *Package) GeneratePatch() error {
 
 // GenerateCharts creates Helm chart archives for each chart after preparing it
 func (p *Package) GenerateCharts() error {
+	if p.DoNotRelease {
+		logrus.Infof("Skipping package marked doNotRelease")
+		return nil
+	}
 	if err := p.Prepare(); err != nil {
 		return fmt.Errorf("Encountered error while trying to prepare package: %s", err)
 	}

--- a/pkg/charts/parse.go
+++ b/pkg/charts/parse.go
@@ -99,6 +99,7 @@ func GetPackage(rootFs billy.Filesystem, name string) (*Package, error) {
 		PackageVersion:          packageOpt.PackageVersion,
 		AdditionalCharts:        additionalCharts,
 		ReleaseCandidateVersion: packageOpt.ReleaseCandidateVersion,
+		DoNotRelease:            packageOpt.DoNotRelease,
 
 		fs:     pkgFs,
 		rootFs: rootFs,

--- a/pkg/options/package.go
+++ b/pkg/options/package.go
@@ -21,6 +21,8 @@ type PackageOptions struct {
 	MainChartOptions ChartOptions `yaml:",inline"`
 	// AdditionalChartOptions represent options presented to the user to configure any additional charts
 	AdditionalChartOptions []AdditionalChartOptions `yaml:"additionalCharts,omitempty"`
+	// DoNotRelease represents a boolean flag that indicates a package should not be tracked in make charts
+	DoNotRelease bool `yaml:"doNotRelease,omitempty"`
 }
 
 // LoadPackageOptionsFromFile unmarshalls the struct found at the file to YAML and reads it into memory


### PR DESCRIPTION
Allows a user to specify that a chart should not be released via adding `doNotRelease: true` to the `package.yaml`.

This just adds a flag on top of `make charts`, which in turn blocks `make sync` or `make validate`.

Does not block `make prepare` or `make patch` (if non-local).

The purpose behind this PR is to support avoiding the release of charts like rancher-kiali-server or cilium-original that may not make sense to release as standalone charts in our repository.