### PR TITLE
Fix OpenFile flags to avoid garbled files

### DIFF
--- a/pkg/charts/dependencies.go
+++ b/pkg/charts/dependencies.go
@@ -294,7 +294,7 @@ func UpdateHelmMetadataWithDependencies(fs billy.Filesystem, mainHelmChartPath s
 	if !exists {
 		file, err = filesystem.CreateFileAndDirs(fs, path)
 	} else {
-		file, err = fs.OpenFile(path, os.O_RDWR, os.ModePerm)
+		file, err = fs.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.ModePerm)
 	}
 	if err != nil {
 		return err

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -137,7 +137,7 @@ func CopyFile(fs billy.Filesystem, srcPath string, dstPath string) error {
 	if !dstExists {
 		dstFile, err = CreateFileAndDirs(fs, dstPath)
 	} else {
-		dstFile, err = fs.OpenFile(dstPath, os.O_WRONLY, os.ModePerm)
+		dstFile, err = fs.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
 	}
 	if err != nil {
 		return err
@@ -184,7 +184,7 @@ func UnarchiveTgz(fs billy.Filesystem, tgzPath, tgzSubdirectory, destPath string
 		}
 	}
 	// Check if you can open the tgzPath as a tar file
-	tgz, err := fs.OpenFile(tgzPath, os.O_RDWR, os.ModePerm)
+	tgz, err := fs.OpenFile(tgzPath, os.O_RDONLY, os.ModePerm)
 	if err != nil {
 		return err
 	}

--- a/pkg/helm/metadata.go
+++ b/pkg/helm/metadata.go
@@ -26,7 +26,7 @@ func UpdateHelmMetadataWithName(fs billy.Filesystem, mainHelmChartPath string, n
 	if err != nil {
 		return err
 	}
-	file, err := fs.OpenFile(path, os.O_RDWR, os.ModePerm)
+	file, err := fs.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.ModePerm)
 	if err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ func TrimRCVersionFromHelmChart(fs billy.Filesystem, mainHelmChartPath string) e
 	if err != nil {
 		return err
 	}
-	file, err := fs.OpenFile(path, os.O_RDWR, os.ModePerm)
+	file, err := fs.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.ModePerm)
 	if err != nil {
 		return err
 	}

--- a/pkg/options/chart.go
+++ b/pkg/options/chart.go
@@ -59,7 +59,7 @@ func (c ChartOptions) WriteToFile(fs billy.Filesystem, path string) error {
 	if !exists {
 		file, err = filesystem.CreateFileAndDirs(fs, path)
 	} else {
-		file, err = fs.OpenFile(path, os.O_RDWR, os.ModePerm)
+		file, err = fs.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.ModePerm)
 	}
 	if err != nil {
 		return err

--- a/pkg/options/package.go
+++ b/pkg/options/package.go
@@ -54,7 +54,7 @@ func (p PackageOptions) WriteToFile(fs billy.Filesystem, path string) error {
 	if !exists {
 		file, err = filesystem.CreateFileAndDirs(fs, path)
 	} else {
-		file, err = fs.OpenFile(path, os.O_RDWR, os.ModePerm)
+		file, err = fs.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.ModePerm)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
Reviewed and corrected `OpenFile` flags:

* added flag `os.O_TRUNC` to prevent leftovers at the end of exisitng files when new data does not overflow existing data.
* added flag `os.O_CREATE` to create file if is does not exist as is the most reasonable thing to do other than exceptions
* changed flag `os.O_RDWR` to `os.O_RDONLY` for files that are only read from.



