### PR TITLE
add 'version' to the package.yaml file

### DIFF
--- a/pkg/charts/additionalchart.go
+++ b/pkg/charts/additionalchart.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/blang/semver"
 	"github.com/go-git/go-billy/v5"
 	"github.com/rancher/charts-build-scripts/pkg/change"
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
@@ -185,11 +186,11 @@ func (c *AdditionalChart) GeneratePatch(rootFs, pkgFs billy.Filesystem) error {
 }
 
 // GenerateChart generates the chart and stores it in the assets and charts directory
-func (c *AdditionalChart) GenerateChart(rootFs, pkgFs billy.Filesystem, packageVersion int, packageAssetsDirpath, packageChartsDirpath string) error {
+func (c *AdditionalChart) GenerateChart(rootFs, pkgFs billy.Filesystem, packageVersion *int, version *semver.Version, packageAssetsDirpath, packageChartsDirpath string) error {
 	if c.upstreamChartVersion == nil {
 		return fmt.Errorf("Cannot generate chart since it has never been prepared: upstreamChartVersion is not set")
 	}
-	if err := helm.ExportHelmChart(rootFs, pkgFs, c.WorkingDir, packageVersion, *c.upstreamChartVersion, packageAssetsDirpath, packageChartsDirpath); err != nil {
+	if err := helm.ExportHelmChart(rootFs, pkgFs, c.WorkingDir, packageVersion, version, *c.upstreamChartVersion, packageAssetsDirpath, packageChartsDirpath); err != nil {
 		return fmt.Errorf("Encountered error while trying to export Helm chart for %s: %s", c.WorkingDir, err)
 	}
 	return nil

--- a/pkg/charts/chart.go
+++ b/pkg/charts/chart.go
@@ -3,6 +3,7 @@ package charts
 import (
 	"fmt"
 
+	"github.com/blang/semver"
 	"github.com/go-git/go-billy/v5"
 	"github.com/rancher/charts-build-scripts/pkg/change"
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
@@ -81,11 +82,11 @@ func (c *Chart) GeneratePatch(rootFs, pkgFs billy.Filesystem) error {
 }
 
 // GenerateChart generates the chart and stores it in the assets and charts directory
-func (c *Chart) GenerateChart(rootFs, pkgFs billy.Filesystem, packageVersion int, packageAssetsDirpath, packageChartsDirpath string) error {
+func (c *Chart) GenerateChart(rootFs, pkgFs billy.Filesystem, packageVersion *int, version *semver.Version, packageAssetsDirpath, packageChartsDirpath string) error {
 	if c.upstreamChartVersion == nil {
 		return fmt.Errorf("Cannot generate chart since it has never been prepared: upstreamChartVersion is not set")
 	}
-	if err := helm.ExportHelmChart(rootFs, pkgFs, c.WorkingDir, packageVersion, *c.upstreamChartVersion, packageAssetsDirpath, packageChartsDirpath); err != nil {
+	if err := helm.ExportHelmChart(rootFs, pkgFs, c.WorkingDir, packageVersion, version, *c.upstreamChartVersion, packageAssetsDirpath, packageChartsDirpath); err != nil {
 		return fmt.Errorf("Encountered error while trying to export Helm chart for %s: %s", c.WorkingDir, err)
 	}
 	return nil

--- a/pkg/charts/package.go
+++ b/pkg/charts/package.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/blang/semver"
 	"github.com/go-git/go-billy/v5"
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
 	"github.com/rancher/charts-build-scripts/pkg/helm"
@@ -17,8 +18,10 @@ type Package struct {
 
 	// Name is the name of the package
 	Name string `yaml:"name"`
+	// Version represents the version of the package. It will override other values if it exists
+	Version *semver.Version `yaml:"version,omitempty"`
 	// PackageVersion represents the current version of the package. It needs to be incremented whenever there are changes
-	PackageVersion int `yaml:"packageVersion"`
+	PackageVersion *int `yaml:"packageVersion"`
 	// AdditionalCharts are other charts that should be packaged together with this
 	AdditionalCharts []*AdditionalChart `yaml:"additionalCharts,omitempty"`
 	// DoNotRelease represents a boolean flag that indicates a package should not be tracked in make charts
@@ -95,12 +98,12 @@ func (p *Package) GenerateCharts() error {
 	packageAssetsDirpath := filepath.Join(path.RepositoryAssetsDir, p.Name)
 	packageChartsDirpath := filepath.Join(path.RepositoryChartsDir, p.Name)
 	// Add PackageVersion to format
-	err := p.Chart.GenerateChart(p.rootFs, p.fs, p.PackageVersion, packageAssetsDirpath, packageChartsDirpath)
+	err := p.Chart.GenerateChart(p.rootFs, p.fs, p.PackageVersion, p.Version, packageAssetsDirpath, packageChartsDirpath)
 	if err != nil {
 		return fmt.Errorf("Encountered error while exporting main chart: %s", err)
 	}
 	for _, additionalChart := range p.AdditionalCharts {
-		err = additionalChart.GenerateChart(p.rootFs, p.fs, p.PackageVersion, packageAssetsDirpath, packageChartsDirpath)
+		err = additionalChart.GenerateChart(p.rootFs, p.fs, p.PackageVersion, p.Version, packageAssetsDirpath, packageChartsDirpath)
 		if err != nil {
 			return fmt.Errorf("Encountered error while exporting %s: %s", additionalChart.WorkingDir, err)
 		}

--- a/pkg/helm/export.go
+++ b/pkg/helm/export.go
@@ -27,7 +27,7 @@ var (
 // helmChartPath is a relative path (rooted at the package level) that contains the chart.
 // packageAssetsPath is a relative path (rooted at the repository level) where the generated chart archive will be placed
 // packageChartsPath is a relative path (rooted at the repository level) where the generated chart will be placed
-func ExportHelmChart(rootFs, fs billy.Filesystem, helmChartPath string, packageVersion int, upstreamChartVersion, packageAssetsDirpath, packageChartsDirpath string) error {
+func ExportHelmChart(rootFs, fs billy.Filesystem, helmChartPath string, packageVersion *int, version *semver.Version, upstreamChartVersion, packageAssetsDirpath, packageChartsDirpath string) error {
 	// Try to load the chart to see if it can be exported
 	absHelmChartPath := filesystem.GetAbsPath(fs, helmChartPath)
 	chart, err := helmLoader.Load(absHelmChartPath)
@@ -41,12 +41,17 @@ func ExportHelmChart(rootFs, fs billy.Filesystem, helmChartPath string, packageV
 	if err != nil {
 		return fmt.Errorf("Cannot parse original chart version %s as valid semver", chart.Metadata.Version)
 	}
-	// Add packageVersion as string, preventing errors due to leading 0s
-	if uint64(packageVersion) >= MaxPatchNum {
-		return fmt.Errorf("Maximum number of packageVersions is %d, found %d", MaxPatchNum, packageVersion)
+	if version != nil {
+		chartVersionSemver = *version
+	} else if packageVersion != nil {
+		// Add packageVersion as string, preventing errors due to leading 0s
+		if uint64(*packageVersion) >= MaxPatchNum {
+			return fmt.Errorf("Maximum number of packageVersions is %d, found %d", MaxPatchNum, packageVersion)
+		}
+		chartVersionSemver.Patch = PatchNumMultiplier*chartVersionSemver.Patch + uint64(*packageVersion)
 	}
-	chartVersionSemver.Patch = PatchNumMultiplier*chartVersionSemver.Patch + uint64(packageVersion)
-	if len(upstreamChartVersion) > 0 {
+
+	if len(upstreamChartVersion) > 0 && upstreamChartVersion != chartVersionSemver.String() {
 		// Add buildMetadataFlag for forked charts
 		chartVersionSemver.Build = append(chartVersionSemver.Build, fmt.Sprintf("up%s", upstreamChartVersion))
 	}

--- a/pkg/options/package.go
+++ b/pkg/options/package.go
@@ -13,8 +13,10 @@ import (
 // PackageOptions represent the options presented to users to be able to configure the way a package is built using these scripts
 // The YAML that corresponds to these options are stored within packages/<package-name>/package.yaml for each package
 type PackageOptions struct {
+	// Version represents the version of the package. It will override other values if it exists
+	Version *string `yaml:"version,omitempty"`
 	// PackageVersion represents the current version of the package. It needs to be incremented whenever there are changes
-	PackageVersion int `yaml:"packageVersion" default:"0"`
+	PackageVersion *int `yaml:"packageVersion" default:"0"`
 	// MainChartOptions represent options presented to the user to configure the main chart
 	MainChartOptions ChartOptions `yaml:",inline"`
 	// AdditionalChartOptions represent options presented to the user to configure any additional charts

--- a/templates/template/packages/README.md
+++ b/templates/template/packages/README.md
@@ -5,7 +5,8 @@
 A Package represents a grouping of one or more Helm Charts. It is declared within `packages/<package>/package.yaml` with the following spec:
 
 ```text
-packageVersion: 0
+version: # The version of the generated chart. This value will override the upstream chart's version. Mutually exclusive with packageVersion
+packageVersion: 1 # The value range is from 1 to 99. Mutually exclusive with version
 workingDir: # The directory within your package that will contain your working copy of the chart (e.g. charts)
 url: # A URL pointing to an UpstreamConfiguration
 subdirectory: # Optional field for a specific subdirectory for all upstreams


### PR DESCRIPTION
Issue: https://github.com/rancher/charts-build-scripts/issues/45

The following cases have been tested:
the package.yaml contains
- only version
- only packageVersion
- both version and packageVersion
- none of them 