### PR TITLE
Remove Github Workflow from update

### DIFF
--- a/templates/update.yaml
+++ b/templates/update.yaml
@@ -1,7 +1,6 @@
 staging:
 - README.md
 - .gitignore
-- .github/workflows/pull-request.yaml
 - scripts/pull-scripts
 - scripts/package-ci
 - scripts/regenerate-packages


### PR DESCRIPTION
On running a `make template` today in dev-v2.6:
```bash
arvindiyengar: ~/Rancher/charts/src/github.com/rancher/charts 
$ git status
On branch add-kubelet-pushprox
Your branch is up to date with 'origin/add-kubelet-pushprox'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   .github/workflows/pull-request.yaml
        modified:   Makefile
        modified:   packages/README.md
        modified:   scripts/pull-scripts

no changes added to commit (use "git add" and/or "git commit -a")
```

We should not be updating the .github/workflows/pull-request.yaml since it is hard-coded to dev-v2.5 today:
https://github.com/rancher/charts-build-scripts/blob/d150c67700f8a265189d995bd3024ef19c92de80/templates/template/.github/workflows/pull-request.yaml#L6

There's also nothing in the configuration.yaml anymore that would allow us to guess what this value should be.