### PR TITLE
fix patch version

### DIFF
--- a/pkg/helm/export.go
+++ b/pkg/helm/export.go
@@ -48,7 +48,9 @@ func ExportHelmChart(rootFs, fs billy.Filesystem, helmChartPath string, packageV
 		if uint64(*packageVersion) >= MaxPatchNum {
 			return fmt.Errorf("Maximum number of packageVersions is %d, found %d", MaxPatchNum, packageVersion)
 		}
-		chartVersionSemver.Patch = PatchNumMultiplier*chartVersionSemver.Patch + uint64(*packageVersion)
+		if uint64(*packageVersion) > 0 {
+			chartVersionSemver.Patch = PatchNumMultiplier*chartVersionSemver.Patch + uint64(*packageVersion)
+		}
 	}
 
 	if len(upstreamChartVersion) > 0 && upstreamChartVersion != chartVersionSemver.String() {


### PR DESCRIPTION
Problem:
In the case where we want to use the upstream version as the chart version, such as the Fleet chart,  we will not set the `Version` or `packageVersion` in the `packages.yaml`. But for the back-compatibility, we allow the `packageVersion` to be set to 0. This causes the patch is changed to a 3-dight number and results in an unexpected chart version. 

For example,  with this package.yaml 
```
url: https://github.com/rancher/fleet/releases/download/v0.3.5/fleet-0.3.5.tgz
packageVersion: 0
```
we expect to generate the Fleet chart `0.3.5` but we actually get `0.3.500+up0.3.5`

Fix:
Check the value of `packageVersion` and skip changing the patch if `packageVersion` is 0  


This bug is not found before because I used the rancher-prom2teams chart, which upstream's patch is 0,  to do the tests. 