### PR TITLE
Add ability to omitBuildMetadata on repository

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,8 +150,9 @@ func generateCharts(c *cli.Context) {
 	}
 	// Generate charts
 	packages := getPackages()
+	chartsScriptOptions := parseScriptOptions()
 	for _, p := range packages {
-		if err := p.GenerateCharts(); err != nil {
+		if err := p.GenerateCharts(chartsScriptOptions.OmitBuildMetadataOnExport); err != nil {
 			logrus.Fatal(err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 			Name:   "charts",
 			Usage:  "Create a local chart archive of your finalized chart for testing",
 			Action: generateCharts,
-			Flags:  []cli.Flag{packageFlag},
+			Flags:  []cli.Flag{packageFlag, configFlag},
 		},
 		{
 			Name:   "clean",

--- a/pkg/charts/additionalchart.go
+++ b/pkg/charts/additionalchart.go
@@ -186,11 +186,11 @@ func (c *AdditionalChart) GeneratePatch(rootFs, pkgFs billy.Filesystem) error {
 }
 
 // GenerateChart generates the chart and stores it in the assets and charts directory
-func (c *AdditionalChart) GenerateChart(rootFs, pkgFs billy.Filesystem, packageVersion *int, version *semver.Version, packageAssetsDirpath, packageChartsDirpath string) error {
+func (c *AdditionalChart) GenerateChart(rootFs, pkgFs billy.Filesystem, packageVersion *int, version *semver.Version, packageAssetsDirpath, packageChartsDirpath string, omitBuildMetadataOnExport bool) error {
 	if c.upstreamChartVersion == nil {
 		return fmt.Errorf("Cannot generate chart since it has never been prepared: upstreamChartVersion is not set")
 	}
-	if err := helm.ExportHelmChart(rootFs, pkgFs, c.WorkingDir, packageVersion, version, *c.upstreamChartVersion, packageAssetsDirpath, packageChartsDirpath); err != nil {
+	if err := helm.ExportHelmChart(rootFs, pkgFs, c.WorkingDir, packageVersion, version, *c.upstreamChartVersion, packageAssetsDirpath, packageChartsDirpath, omitBuildMetadataOnExport); err != nil {
 		return fmt.Errorf("Encountered error while trying to export Helm chart for %s: %s", c.WorkingDir, err)
 	}
 	return nil

--- a/pkg/charts/chart.go
+++ b/pkg/charts/chart.go
@@ -82,11 +82,11 @@ func (c *Chart) GeneratePatch(rootFs, pkgFs billy.Filesystem) error {
 }
 
 // GenerateChart generates the chart and stores it in the assets and charts directory
-func (c *Chart) GenerateChart(rootFs, pkgFs billy.Filesystem, packageVersion *int, version *semver.Version, packageAssetsDirpath, packageChartsDirpath string) error {
+func (c *Chart) GenerateChart(rootFs, pkgFs billy.Filesystem, packageVersion *int, version *semver.Version, packageAssetsDirpath, packageChartsDirpath string, omitBuildMetadataOnExport bool) error {
 	if c.upstreamChartVersion == nil {
 		return fmt.Errorf("Cannot generate chart since it has never been prepared: upstreamChartVersion is not set")
 	}
-	if err := helm.ExportHelmChart(rootFs, pkgFs, c.WorkingDir, packageVersion, version, *c.upstreamChartVersion, packageAssetsDirpath, packageChartsDirpath); err != nil {
+	if err := helm.ExportHelmChart(rootFs, pkgFs, c.WorkingDir, packageVersion, version, *c.upstreamChartVersion, packageAssetsDirpath, packageChartsDirpath, omitBuildMetadataOnExport); err != nil {
 		return fmt.Errorf("Encountered error while trying to export Helm chart for %s: %s", c.WorkingDir, err)
 	}
 	return nil

--- a/pkg/charts/package.go
+++ b/pkg/charts/package.go
@@ -86,7 +86,7 @@ func (p *Package) GeneratePatch() error {
 }
 
 // GenerateCharts creates Helm chart archives for each chart after preparing it
-func (p *Package) GenerateCharts() error {
+func (p *Package) GenerateCharts(omitBuildMetadataOnExport bool) error {
 	if p.DoNotRelease {
 		logrus.Infof("Skipping package marked doNotRelease")
 		return nil
@@ -98,12 +98,12 @@ func (p *Package) GenerateCharts() error {
 	packageAssetsDirpath := filepath.Join(path.RepositoryAssetsDir, p.Name)
 	packageChartsDirpath := filepath.Join(path.RepositoryChartsDir, p.Name)
 	// Add PackageVersion to format
-	err := p.Chart.GenerateChart(p.rootFs, p.fs, p.PackageVersion, p.Version, packageAssetsDirpath, packageChartsDirpath)
+	err := p.Chart.GenerateChart(p.rootFs, p.fs, p.PackageVersion, p.Version, packageAssetsDirpath, packageChartsDirpath, omitBuildMetadataOnExport)
 	if err != nil {
 		return fmt.Errorf("Encountered error while exporting main chart: %s", err)
 	}
 	for _, additionalChart := range p.AdditionalCharts {
-		err = additionalChart.GenerateChart(p.rootFs, p.fs, p.PackageVersion, p.Version, packageAssetsDirpath, packageChartsDirpath)
+		err = additionalChart.GenerateChart(p.rootFs, p.fs, p.PackageVersion, p.Version, packageAssetsDirpath, packageChartsDirpath, omitBuildMetadataOnExport)
 		if err != nil {
 			return fmt.Errorf("Encountered error while exporting %s: %s", additionalChart.WorkingDir, err)
 		}

--- a/pkg/helm/export.go
+++ b/pkg/helm/export.go
@@ -27,7 +27,7 @@ var (
 // helmChartPath is a relative path (rooted at the package level) that contains the chart.
 // packageAssetsPath is a relative path (rooted at the repository level) where the generated chart archive will be placed
 // packageChartsPath is a relative path (rooted at the repository level) where the generated chart will be placed
-func ExportHelmChart(rootFs, fs billy.Filesystem, helmChartPath string, packageVersion *int, version *semver.Version, upstreamChartVersion, packageAssetsDirpath, packageChartsDirpath string) error {
+func ExportHelmChart(rootFs, fs billy.Filesystem, helmChartPath string, packageVersion *int, version *semver.Version, upstreamChartVersion, packageAssetsDirpath, packageChartsDirpath string, omitBuildMetadata bool) error {
 	// Try to load the chart to see if it can be exported
 	absHelmChartPath := filesystem.GetAbsPath(fs, helmChartPath)
 	chart, err := helmLoader.Load(absHelmChartPath)
@@ -51,7 +51,7 @@ func ExportHelmChart(rootFs, fs billy.Filesystem, helmChartPath string, packageV
 		chartVersionSemver.Patch = PatchNumMultiplier*chartVersionSemver.Patch + uint64(*packageVersion)
 	}
 
-	if len(upstreamChartVersion) > 0 && upstreamChartVersion != chartVersionSemver.String() {
+	if !omitBuildMetadata && len(upstreamChartVersion) > 0 && upstreamChartVersion != chartVersionSemver.String() {
 		// Add buildMetadataFlag for forked charts
 		chartVersionSemver.Build = append(chartVersionSemver.Build, fmt.Sprintf("up%s", upstreamChartVersion))
 	}

--- a/pkg/options/script.go
+++ b/pkg/options/script.go
@@ -8,6 +8,9 @@ type ChartsScriptOptions struct {
 	HelmRepoConfiguration `yaml:"helmRepo"`
 	// Template can be 'staging' or 'live'
 	Template string `yaml:"template"`
+	// OmitBuildMetadataOnExport instructs the scripts to not add in a +up build metadata flag for forked charts
+	// If false, any forked chart whose version differs from the original source version will have the version VERSION+upORIGINAL_VERSION
+	OmitBuildMetadataOnExport bool `yaml:"omitBuildMetadataOnExport"`
 }
 
 // ValidateOptions represent any options that are configurable when validating a chart


### PR DESCRIPTION
Currently, charts-build-script automatically appends a `+upORIGINALVERSION` annotation to any non-local chart that has a different version than its upstream version.

This commit adds a repository-level configuration that can be set to remove that feature.