### PR TITLE
Output error when package is not set for patch

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,10 +130,11 @@ func prepareCharts(c *cli.Context) {
 
 func generatePatch(c *cli.Context) {
 	packages := getPackages()
-	for _, p := range packages {
-		if err := p.GeneratePatch(); err != nil {
-			logrus.Fatal(err)
-		}
+	if len(packages) != 1 {
+		logrus.Fatalf("No PACKAGE is set. Run export PACKAGE=<package> before running this command.")
+	}
+	if err := packages[0].GeneratePatch(); err != nil {
+		logrus.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
It's never reasonable to run a patch on **everything** in the repository. So this commit ensures that you can only run patch when a specific package is set.

```
arvindiyengar: ~/Rancher/charts/src/github.com/rancher/charts
$ make patch
FATA[0000] No PACKAGE is set. Run export PACKAGE=<package> before running this command.
make: *** [patch] Error 1
```