### PR TITLE
add the step of combining all CRD files into a single compressed file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 *.swp
 .idea
 charts-build-scripts
+.DS_Store
+pkg/.DS_Store
+templates/.DS_Store

--- a/pkg/charts/additionalchart.go
+++ b/pkg/charts/additionalchart.go
@@ -45,21 +45,20 @@ func (c *AdditionalChart) ApplyMainChanges(pkgFs billy.Filesystem) error {
 		return fmt.Errorf("Encountered error while trying to get the main chart's working directory: %s", err)
 	}
 	if c.CRDChartOptions.UseTarArchive {
-		if err := helm.ArchiveCRDs(pkgFs, mainChartWorkingDir, path.ChartCRDDir, c.WorkingDir, c.CRDChartOptions.CRDDirectory); err != nil {
+		if err := helm.ArchiveCRDs(pkgFs, mainChartWorkingDir, path.ChartCRDDir, c.WorkingDir, path.ChartExtraFileDir); err != nil {
 			return fmt.Errorf("encountered error while trying to bundle and compress CRD files from the main chart: %s", err)
 		}
-	} else {
-		if err := helm.CopyCRDsFromChart(pkgFs, mainChartWorkingDir, path.ChartCRDDir, c.WorkingDir, c.CRDChartOptions.CRDDirectory); err != nil {
-			return fmt.Errorf("Encountered error while trying to copy CRDs from %s to %s: %s", mainChartWorkingDir, c.WorkingDir, err)
-		}
 	}
-	if c.CRDChartOptions.AddCRDValidationToMainChart {
-		if err := AddCRDValidationToChart(pkgFs, mainChartWorkingDir, mainChartWorkingDir, path.ChartCRDDir); err != nil {
-			return fmt.Errorf("Encountered error while trying to add CRD validation to %s based on CRDs in %s: %s", mainChartWorkingDir, c.WorkingDir, err)
-		}
+	if err := helm.CopyCRDsFromChart(pkgFs, mainChartWorkingDir, path.ChartCRDDir, c.WorkingDir, c.CRDChartOptions.CRDDirectory); err != nil {
+		return fmt.Errorf("Encountered error while trying to copy CRDs from %s to %s: %s", mainChartWorkingDir, c.WorkingDir, err)
 	}
 	if err := helm.DeleteCRDsFromChart(pkgFs, mainChartWorkingDir); err != nil {
 		return fmt.Errorf("Encountered error while trying to delete CRDs from main chart: %s", err)
+	}
+	if c.CRDChartOptions.AddCRDValidationToMainChart {
+		if err := AddCRDValidationToChart(pkgFs, mainChartWorkingDir, c.WorkingDir, c.CRDChartOptions.CRDDirectory); err != nil {
+			return fmt.Errorf("Encountered error while trying to add CRD validation to %s based on CRDs in %s: %s", mainChartWorkingDir, c.WorkingDir, err)
+		}
 	}
 	return nil
 }
@@ -79,19 +78,9 @@ func (c *AdditionalChart) RevertMainChanges(pkgFs billy.Filesystem) error {
 	if err != nil {
 		return fmt.Errorf("Encountered error while trying to get the main chart's working directory: %s", err)
 	}
-	if c.CRDChartOptions.UseTarArchive {
-		// e.g. tgzPath = "charts-crd/crd-manifest/crd-manifest.tgz"
-		// e.g. destPath = "charts/crds"
-		tgzPath := filepath.Join(c.WorkingDir, c.CRDChartOptions.CRDDirectory, fmt.Sprintf("%s.tgz", c.CRDChartOptions.CRDDirectory))
-		destPath := filepath.Join(mainChartWorkingDir, path.ChartCRDDir)
-		if err := filesystem.UnarchiveTgz(pkgFs, tgzPath, path.ChartCRDDir, destPath, true); err != nil {
-			return fmt.Errorf("encountered error while trying to decompress and unarchve the CRD files: %s", err)
-		}
-	} else {
-		// copy CRD files from packages/<package>/charts-crd/crd-manifest/ to packages/<package>/charts/crds/
-		if err := helm.CopyCRDsFromChart(pkgFs, c.WorkingDir, c.CRDChartOptions.CRDDirectory, mainChartWorkingDir, path.ChartCRDDir); err != nil {
-			return fmt.Errorf("Encountered error while trying to copy CRDs from %s to %s: %s", c.WorkingDir, mainChartWorkingDir, err)
-		}
+	// copy CRD files from packages/<package>/charts-crd/crd-manifest/ to packages/<package>/charts/crds/
+	if err := helm.CopyCRDsFromChart(pkgFs, c.WorkingDir, c.CRDChartOptions.CRDDirectory, mainChartWorkingDir, path.ChartCRDDir); err != nil {
+		return fmt.Errorf("Encountered error while trying to copy CRDs from %s to %s: %s", c.WorkingDir, mainChartWorkingDir, err)
 	}
 	if c.CRDChartOptions.AddCRDValidationToMainChart {
 		if err := RemoveCRDValidationFromChart(pkgFs, mainChartWorkingDir); err != nil {

--- a/pkg/charts/additionalchart.go
+++ b/pkg/charts/additionalchart.go
@@ -84,7 +84,7 @@ func (c *AdditionalChart) RevertMainChanges(pkgFs billy.Filesystem) error {
 		// e.g. destPath = "charts/crds"
 		tgzPath := filepath.Join(c.WorkingDir, c.CRDChartOptions.CRDDirectory, fmt.Sprintf("%s.tgz", c.CRDChartOptions.CRDDirectory))
 		destPath := filepath.Join(mainChartWorkingDir, path.ChartCRDDir)
-		if err := filesystem.UnarchiveTgz(pkgFs, tgzPath, "", destPath, true); err != nil {
+		if err := filesystem.UnarchiveTgz(pkgFs, tgzPath, path.ChartCRDDir, destPath, true); err != nil {
 			return fmt.Errorf("encountered error while trying to decompress and unarchve the CRD files: %s", err)
 		}
 	} else {

--- a/pkg/charts/additionalchart.go
+++ b/pkg/charts/additionalchart.go
@@ -78,7 +78,7 @@ func (c *AdditionalChart) RevertMainChanges(pkgFs billy.Filesystem) error {
 	if err != nil {
 		return fmt.Errorf("Encountered error while trying to get the main chart's working directory: %s", err)
 	}
-	// copy CRD files from packages/<package>/charts-crd/crd-manifest/ to packages/<package>/charts/crds/
+	// copy CRD files from packages/<package>/charts-crd/crd-manifest/ back to packages/<package>/charts/crds/
 	if err := helm.CopyCRDsFromChart(pkgFs, c.WorkingDir, c.CRDChartOptions.CRDDirectory, mainChartWorkingDir, path.ChartCRDDir); err != nil {
 		return fmt.Errorf("Encountered error while trying to copy CRDs from %s to %s: %s", c.WorkingDir, mainChartWorkingDir, err)
 	}

--- a/pkg/charts/package.go
+++ b/pkg/charts/package.go
@@ -39,6 +39,7 @@ func (p *Package) Prepare() error {
 		return fmt.Errorf("Encountered error while preparing main chart: %s", err)
 	}
 	if p.Chart.Upstream.IsWithinPackage() {
+		// in the case of local chart
 		for _, additionalChart := range p.AdditionalCharts {
 			exists, err := filesystem.PathExists(p.fs, additionalChart.WorkingDir)
 			if err != nil {

--- a/pkg/charts/parse.go
+++ b/pkg/charts/parse.go
@@ -175,6 +175,7 @@ func GetAdditionalChartFromOptions(opt options.AdditionalChartOptions) (Addition
 			TemplateDirectory:           templateDirectory,
 			CRDDirectory:                crdDirectory,
 			AddCRDValidationToMainChart: opt.CRDChartOptions.AddCRDValidationToMainChart,
+			UseTarArchive:               opt.CRDChartOptions.UseTarArchive,
 		}
 	}
 	return a, nil

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -267,9 +267,6 @@ func ArchiveDir(fs billy.Filesystem, srcPath, destTgzPath string) error {
 	defer tarWriter.Close()
 
 	return WalkDir(fs, srcPath, func(fs billy.Filesystem, path string, isDir bool) error {
-		if isDir {
-			return nil
-		}
 		info, err := fs.Stat(path)
 		if err != nil {
 			return err
@@ -282,6 +279,10 @@ func ArchiveDir(fs billy.Filesystem, srcPath, destTgzPath string) error {
 		header.Name = path
 		if err := tarWriter.WriteHeader(header); err != nil {
 			return err
+		}
+		// The directory structure is preserved, but there is no data to read from a Dir
+		if isDir {
+			return nil
 		}
 		file, err := fs.Open(path)
 		if err != nil {

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -150,7 +150,7 @@ func CopyFile(fs billy.Filesystem, srcPath string, dstPath string) error {
 	return nil
 }
 
-// GetChartArchive gets a chart tgz file from an url and drops it into the path specified on the filesystem
+// GetChartArchive gets a chart tgz file from a url and drops it into the path specified on the filesystem
 func GetChartArchive(fs billy.Filesystem, url string, path string) error {
 	// Create file
 	tgz, err := CreateFileAndDirs(fs, path)
@@ -252,7 +252,7 @@ func UnarchiveTgz(fs billy.Filesystem, tgzPath, tgzSubdirectory, destPath string
 // ArchiveDir archives a directory or a file into a tgz file and put it at destTgzPath which should end with .tgz
 func ArchiveDir(fs billy.Filesystem, srcPath, destTgzPath string) error {
 	if !strings.HasSuffix(destTgzPath, ".tgz") {
-		return fmt.Errorf("the destTgzPath %s does not end with .tgz", destTgzPath)
+		return fmt.Errorf("cannot archive %s to %s since the archive path does not end with '.tgz'", srcPath, destTgzPath)
 	}
 	tgzFile, err := fs.Create(destTgzPath)
 	if err != nil {
@@ -280,7 +280,7 @@ func ArchiveDir(fs billy.Filesystem, srcPath, destTgzPath string) error {
 		if err := tarWriter.WriteHeader(header); err != nil {
 			return err
 		}
-		// The directory structure is preserved, but there is no data to read from a Dir
+		// The directory structure is preserved, but there is no data to read from a directory
 		if isDir {
 			return nil
 		}

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -278,6 +278,8 @@ func ArchiveDir(fs billy.Filesystem, srcPath, destTgzPath string) error {
 		if err != nil {
 			return err
 		}
+		// overwrite the name to be the full path to the file
+		header.Name = path
 		if err := tarWriter.WriteHeader(header); err != nil {
 			return err
 		}

--- a/pkg/helm/crds.go
+++ b/pkg/helm/crds.go
@@ -59,7 +59,7 @@ func ArchiveCRDs(fs billy.Filesystem, srcHelmChartPath, srcCRDsDir, dstHelmChart
 		return err
 	}
 	srcCRDsDirPath := filepath.Join(srcHelmChartPath, srcCRDsDir)
-	dstFilePath := filepath.Join(dstHelmChartPath, destCRDsDir, fmt.Sprintf("%s.tgz", destCRDsDir))
+	dstFilePath := filepath.Join(dstHelmChartPath, destCRDsDir, fmt.Sprintf("%s.tgz", "crd-manifest"))
 	logrus.Infof("Compressing CRDs from %s to %s", srcCRDsDirPath, dstFilePath)
 	return filesystem.ArchiveDir(fs, srcCRDsDirPath, dstFilePath)
 }

--- a/pkg/helm/crds.go
+++ b/pkg/helm/crds.go
@@ -50,7 +50,7 @@ func DeleteCRDsFromChart(fs billy.Filesystem, helmChartPath string) error {
 	return nil
 }
 
-// ArchiveCRDs bundles, compress and save the CRD files from the source to the destination
+// ArchiveCRDs bundles, compresses and saves the CRD files from the source to the destination
 func ArchiveCRDs(fs billy.Filesystem, srcHelmChartPath, srcCRDsDir, dstHelmChartPath, destCRDsDir string) error {
 	if err := filesystem.RemoveAll(fs, filepath.Join(dstHelmChartPath, destCRDsDir)); err != nil {
 		return err

--- a/pkg/helm/crds.go
+++ b/pkg/helm/crds.go
@@ -49,3 +49,17 @@ func DeleteCRDsFromChart(fs billy.Filesystem, helmChartPath string) error {
 	}
 	return nil
 }
+
+// ArchiveCRDs bundles, compress and save the CRD files from the source to the destination
+func ArchiveCRDs(fs billy.Filesystem, srcHelmChartPath, srcCRDsDir, dstHelmChartPath, destCRDsDir string) error {
+	if err := filesystem.RemoveAll(fs, filepath.Join(dstHelmChartPath, destCRDsDir)); err != nil {
+		return err
+	}
+	if err := fs.MkdirAll(filepath.Join(dstHelmChartPath, destCRDsDir), os.ModePerm); err != nil {
+		return err
+	}
+	srcCRDsDirPath := filepath.Join(srcHelmChartPath, srcCRDsDir)
+	dstFilePath := filepath.Join(dstHelmChartPath, destCRDsDir, fmt.Sprintf("%s.tgz", destCRDsDir))
+	logrus.Infof("Compressing CRDs from %s to %s", srcCRDsDirPath, dstFilePath)
+	return filesystem.ArchiveDir(fs, srcCRDsDirPath, dstFilePath)
+}

--- a/pkg/options/additionalchart.go
+++ b/pkg/options/additionalchart.go
@@ -18,6 +18,6 @@ type CRDChartOptions struct {
 	CRDDirectory string `yaml:"crdDirectory" default:"templates"`
 	// Whether to add a validation file to your main chart to check that CRDs exist
 	AddCRDValidationToMainChart bool `yaml:"addCRDValidationToMainChart"`
-	// Whether to bundle and compress CRD files into a tgz file
+	// UseTarArchive indicates whether to bundle and compress CRD files into a tgz file
 	UseTarArchive bool `yaml:"useTarArchive"`
 }

--- a/pkg/options/additionalchart.go
+++ b/pkg/options/additionalchart.go
@@ -18,4 +18,6 @@ type CRDChartOptions struct {
 	CRDDirectory string `yaml:"crdDirectory" default:"templates"`
 	// Whether to add a validation file to your main chart to check that CRDs exist
 	AddCRDValidationToMainChart bool `yaml:"addCRDValidationToMainChart"`
+	// Whether to bundle and compress CRD files into a tgz file
+	UseTarArchive bool `yaml:"useTarArchive"`
 }

--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -37,6 +37,8 @@ const (
 
 	// ChartCRDDir represents the directory that we expect to contain CRDs within the chart
 	ChartCRDDir = "crds"
+	// ChartExtraFileDir represents the directory that contains non-YAML files
+	ChartExtraFileDir = "files"
 	// ChartValidateInstallCRDFile is the path to the file pushed to upstream that validates the existence of CRDs in the chart
 	ChartValidateInstallCRDFile = "templates/validate-install-crd.yaml"
 )


### PR DESCRIPTION
Issue:
In the CRD chart, Helm combines all CRD files into one file and saves the file into a configMap, then Helm runs a pod to install/uninstall CRDs by reading the file from the configMap. 
But in the latest monitoring v2 chart, the creation of the configMap fails because the size exceeds the 1MB limit set by k8s. 
Also, the issue cannot be fixed in the Helm chart since Helm does not support compressing files. 

Fix:
When preparing the CRD chart, a new file that combines all CRDs is created and compressed by gzip. Then Helm chart can use this file to create the configMap. 
The CRD-chart templates in the rancher-monitoring package also need to be updated in order to use this new file. https://github.com/rancher/charts/pull/1567