### PR TITLE
fix the validation process 

### DIFF
--- a/pkg/helm/crds.go
+++ b/pkg/helm/crds.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
+	"github.com/rancher/charts-build-scripts/pkg/path"
 	"github.com/sirupsen/logrus"
 	helmLoader "helm.sh/helm/v3/pkg/chart/loader"
 )
@@ -59,7 +60,7 @@ func ArchiveCRDs(fs billy.Filesystem, srcHelmChartPath, srcCRDsDir, dstHelmChart
 		return err
 	}
 	srcCRDsDirPath := filepath.Join(srcHelmChartPath, srcCRDsDir)
-	dstFilePath := filepath.Join(dstHelmChartPath, destCRDsDir, fmt.Sprintf("%s.tgz", "crd-manifest"))
+	dstFilePath := filepath.Join(dstHelmChartPath, destCRDsDir, path.ChartCRDTgzFilename)
 	logrus.Infof("Compressing CRDs from %s to %s", srcCRDsDirPath, dstFilePath)
 	return filesystem.ArchiveDir(fs, srcCRDsDirPath, dstFilePath)
 }

--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -39,6 +39,8 @@ const (
 	ChartCRDDir = "crds"
 	// ChartExtraFileDir represents the directory that contains non-YAML files
 	ChartExtraFileDir = "files"
+	// ChartCRDTgzFilename represents the filename of the crd's tgz file
+	ChartCRDTgzFilename = "crd-manifest.tgz"
 	// ChartValidateInstallCRDFile is the path to the file pushed to upstream that validates the existence of CRDs in the chart
 	ChartValidateInstallCRDFile = "templates/validate-install-crd.yaml"
 )


### PR DESCRIPTION
Add the support for the crd tgz file within the crd chart during the validation process. The crd tgz file is always marked as `Modified` because its metadata is changed when re-generating the chart.  If the crd tgz file is the only files changes in the crd chart, we should ignore it; Otherwise, keep all changes in the crd chart. 

Note:
`make validation` passed when building the binary and running it again my working branch in rancher/charts repo locally 