### PR TITLE
Fix error message on modifying versions of existing charts and add additional docs

### DIFF
--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -29,7 +29,7 @@ type CompareGeneratedAssetsResponse struct {
 
 // PassedValidation returns whether the response seems to indicate that the chart repositories are in sync
 func (r CompareGeneratedAssetsResponse) PassedValidation() bool {
-	return len(r.ModifiedPostRelease) == 0 && len(r.UntrackedInRelease) == 0
+	return len(r.UntrackedInRelease) == 0 && len(r.RemovedPostRelease) == 0 && len(r.ModifiedPostRelease) == 0
 }
 
 // LogDiscrepancies produces logs that can be used to pretty-print why a validation might have failed
@@ -121,7 +121,7 @@ func CompareGeneratedAssets(repoFs billy.Filesystem, u options.UpstreamOptions, 
 			return err
 		}
 		if releaseOptions.Contains(chart.Metadata.Name, chart.Metadata.Version) {
-			// Chart is tracked in release.yaml
+			// Chart is tracked in release.yaml; this chart was removed intentionally
 			return nil
 		}
 		// Chart was removed from local and is not tracked by release.yaml

--- a/templates/template/docs/developing.md
+++ b/templates/template/docs/developing.md
@@ -98,6 +98,10 @@ As a result, developers reviewing your chart can see changes made to `packages/`
 
 You are ready to make a PR!
 
+### Known Issue: Making Changes to the Version of an Existing Package
+
+If you are working with a repository using `charts-build-scripts` that uses remote validation (e.g. `validate.url` and `validate.branch` are provided in the `configuration.yaml`) and you are making a change that would modify the version of an existing package (e.g. replacing a version like `0.1.2-rc3` with `0.1.2-rc4`), please see the section `Modifying Chart Versions That Exist In Upstream` within [`docs/validation.md`](docs/validation.md) for how to ensure CI still passes after making your change.
+
 ### Versioning Packages
 
 Generally, repositories that are using `charts-build-scripts` use one of the following two types of built-in versioning schemes for packages:


### PR DESCRIPTION
Validation should not pass if a chart that exists in upstream is removed **and** an entry does not exist in the release.yaml for it.

Since this use case will occur often for pre-release charts (e.g. on transitioning `0.1.2-rc3 -> 0.1.2-rc4`), I added additional docs on it as well for what needs to be done.