### PR TITLE
Support ignoreDependencies and replacePaths

### DIFF
--- a/pkg/change/apply.go
+++ b/pkg/change/apply.go
@@ -63,22 +63,22 @@ func ApplyChanges(fs billy.Filesystem, toDir, gcRootDir string) error {
 			return err
 		}
 	}
-	exists, err = filesystem.PathExists(fs, chartsOverlayDirpath)
-	if err != nil {
-		return err
-	}
-	if exists {
-		err = filesystem.WalkDir(fs, chartsOverlayDirpath, applyOverlayFile)
-		if err != nil {
-			return err
-		}
-	}
 	exists, err = filesystem.PathExists(fs, chartsExcludeDirpath)
 	if err != nil {
 		return err
 	}
 	if exists {
 		err = filesystem.WalkDir(fs, chartsExcludeDirpath, applyExcludeFile)
+		if err != nil {
+			return err
+		}
+	}
+	exists, err = filesystem.PathExists(fs, chartsOverlayDirpath)
+	if err != nil {
+		return err
+	}
+	if exists {
+		err = filesystem.WalkDir(fs, chartsOverlayDirpath, applyOverlayFile)
 		if err != nil {
 			return err
 		}

--- a/pkg/change/generate.go
+++ b/pkg/change/generate.go
@@ -26,24 +26,6 @@ func GenerateChanges(fs billy.Filesystem, fromDir, toDir, gcRootDir string) erro
 	if err := removeAllGeneratedChanges(fs, gcRootDir); err != nil {
 		return fmt.Errorf("encountered error while trying to remove all existing generated changes before generating new changes: %s", err)
 	}
-	generatePatchFile := func(fs billy.Filesystem, fromPath, toPath string, isDir bool) error {
-		if isDir {
-			return nil
-		}
-		patchPath, err := filesystem.MovePath(fromPath, fromDir, filepath.Join(gcRootDir, path.GeneratedChangesPatchDir))
-		if err != nil {
-			return err
-		}
-		patchPathWithExt := fmt.Sprintf(patchFmt, patchPath)
-		generatedPatch, err := diff.GeneratePatch(fs, patchPathWithExt, fromPath, toPath)
-		if err != nil {
-			return err
-		}
-		if generatedPatch {
-			logrus.Infof("Patch: %s", patchPath)
-		}
-		return nil
-	}
 	generateOverlayFile := func(fs billy.Filesystem, toPath string, isDir bool) error {
 		if isDir {
 			return nil
@@ -70,6 +52,24 @@ func GenerateChanges(fs billy.Filesystem, fromDir, toDir, gcRootDir string) erro
 			return err
 		}
 		logrus.Infof("Exclude: %s", fromPath)
+		return nil
+	}
+	generatePatchFile := func(fs billy.Filesystem, fromPath, toPath string, isDir bool) error {
+		if isDir {
+			return nil
+		}
+		patchPath, err := filesystem.MovePath(fromPath, fromDir, filepath.Join(gcRootDir, path.GeneratedChangesPatchDir))
+		if err != nil {
+			return err
+		}
+		patchPathWithExt := fmt.Sprintf(patchFmt, patchPath)
+		generatedPatch, err := diff.GeneratePatch(fs, patchPathWithExt, fromPath, toPath)
+		if err != nil {
+			return err
+		}
+		if generatedPatch {
+			logrus.Infof("Patch: %s", patchPath)
+		}
 		return nil
 	}
 	return filesystem.CompareDirs(fs, fromDir, toDir, generateExcludeFile, generateOverlayFile, generatePatchFile)

--- a/pkg/charts/additionalchart.go
+++ b/pkg/charts/additionalchart.go
@@ -23,6 +23,8 @@ type AdditionalChart struct {
 	Upstream *puller.Puller `yaml:"upstream"`
 	// CRDChartOptions represents any options that are configurable for CRD charts
 	CRDChartOptions *options.CRDChartOptions `yaml:"crdChart"`
+	// IgnoreDependencies drops certain dependencies from the list that is parsed from upstream
+	IgnoreDependencies []string `yaml:"ignoreDependencies"`
 
 	// The version of this chart in Upstream. This value is set to a non-nil value on Prepare.
 	// GenerateChart will fail if this value is not set (e.g. chart must be prepared first)
@@ -139,7 +141,7 @@ func (c *AdditionalChart) Prepare(rootFs, pkgFs billy.Filesystem, mainChartUpstr
 		}
 		c.upstreamChartVersion = &upstreamChartVersion
 	}
-	if err := PrepareDependencies(rootFs, pkgFs, c.WorkingDir, c.GeneratedChangesRootDir()); err != nil {
+	if err := PrepareDependencies(rootFs, pkgFs, c.WorkingDir, c.GeneratedChangesRootDir(), c.IgnoreDependencies); err != nil {
 		return fmt.Errorf("encountered error while trying to prepare dependencies in %s: %s", c.WorkingDir, err)
 	}
 	if c.Upstream != nil {
@@ -199,7 +201,7 @@ func (c *AdditionalChart) GeneratePatch(rootFs, pkgFs billy.Filesystem) error {
 	if err := helm.ConvertToHelmChart(pkgFs, c.OriginalDir()); err != nil {
 		return fmt.Errorf("encountered error while trying to convert upstream at %s into a Helm chart: %s", c.OriginalDir(), err)
 	}
-	if err := PrepareDependencies(rootFs, pkgFs, c.OriginalDir(), c.GeneratedChangesRootDir()); err != nil {
+	if err := PrepareDependencies(rootFs, pkgFs, c.OriginalDir(), c.GeneratedChangesRootDir(), c.IgnoreDependencies); err != nil {
 		return fmt.Errorf("encountered error while trying to prepare dependencies in %s: %s", c.OriginalDir(), err)
 	}
 	defer filesystem.RemoveAll(pkgFs, c.OriginalDir())

--- a/pkg/charts/additionalchart.go
+++ b/pkg/charts/additionalchart.go
@@ -25,6 +25,8 @@ type AdditionalChart struct {
 	CRDChartOptions *options.CRDChartOptions `yaml:"crdChart"`
 	// IgnoreDependencies drops certain dependencies from the list that is parsed from upstream
 	IgnoreDependencies []string `yaml:"ignoreDependencies"`
+	// ReplacePaths marks paths as those that should be replaced instead of patches. Consequently, these paths will exist in both generated-changes/excludes and generated-changes/overlay
+	ReplacePaths []string `yaml:"replacePaths"`
 
 	// The version of this chart in Upstream. This value is set to a non-nil value on Prepare.
 	// GenerateChart will fail if this value is not set (e.g. chart must be prepared first)
@@ -205,7 +207,7 @@ func (c *AdditionalChart) GeneratePatch(rootFs, pkgFs billy.Filesystem) error {
 		return fmt.Errorf("encountered error while trying to prepare dependencies in %s: %s", c.OriginalDir(), err)
 	}
 	defer filesystem.RemoveAll(pkgFs, c.OriginalDir())
-	if err := change.GenerateChanges(pkgFs, c.OriginalDir(), c.WorkingDir, c.GeneratedChangesRootDir()); err != nil {
+	if err := change.GenerateChanges(pkgFs, c.OriginalDir(), c.WorkingDir, c.GeneratedChangesRootDir(), c.ReplacePaths); err != nil {
 		return fmt.Errorf("encountered error while generating changes from %s to %s and placing it in %s: %s", c.OriginalDir(), c.WorkingDir, c.GeneratedChangesRootDir(), err)
 	}
 	return nil

--- a/pkg/charts/chart.go
+++ b/pkg/charts/chart.go
@@ -21,6 +21,8 @@ type Chart struct {
 	WorkingDir string `yaml:"workingDir" default:"charts"`
 	// IgnoreDependencies drops certain dependencies from the list that is parsed from upstream
 	IgnoreDependencies []string `yaml:"ignoreDependencies"`
+	// ReplacePaths marks paths as those that should be replaced instead of patches. Consequently, these paths will exist in both generated-changes/excludes and generated-changes/overlay
+	ReplacePaths []string `yaml:"replacePaths"`
 
 	// The version of this chart in Upstream. This value is set to a non-nil value on Prepare.
 	// GenerateChart will fail if this value is not set (e.g. chart must be prepared first)
@@ -94,7 +96,7 @@ func (c *Chart) GeneratePatch(rootFs, pkgFs billy.Filesystem) error {
 		return fmt.Errorf("encountered error while trying to prepare dependencies in %s: %s", c.OriginalDir(), err)
 	}
 	defer filesystem.RemoveAll(pkgFs, c.OriginalDir())
-	if err := change.GenerateChanges(pkgFs, c.OriginalDir(), c.WorkingDir, c.GeneratedChangesRootDir()); err != nil {
+	if err := change.GenerateChanges(pkgFs, c.OriginalDir(), c.WorkingDir, c.GeneratedChangesRootDir(), c.ReplacePaths); err != nil {
 		return fmt.Errorf("encountered error while generating changes from %s to %s and placing it in %s: %s", c.OriginalDir(), c.WorkingDir, c.GeneratedChangesRootDir(), err)
 	}
 	return nil

--- a/pkg/charts/dependencies.go
+++ b/pkg/charts/dependencies.go
@@ -22,9 +22,13 @@ import (
 )
 
 // PrepareDependencies prepares all of the dependencies of a given chart and regenerates the requirements.yaml or Chart.yaml
-func PrepareDependencies(rootFs, pkgFs billy.Filesystem, mainHelmChartPath string, gcRootDir string) error {
+func PrepareDependencies(rootFs, pkgFs billy.Filesystem, mainHelmChartPath string, gcRootDir string, ignoreDependencies []string) error {
 	logrus.Infof("Loading dependencies for chart")
-	if err := LoadDependencies(pkgFs, mainHelmChartPath, gcRootDir); err != nil {
+	ignoreDependencyMap := make(map[string]bool)
+	for _, dep := range ignoreDependencies {
+		ignoreDependencyMap[dep] = true
+	}
+	if err := LoadDependencies(pkgFs, mainHelmChartPath, gcRootDir, ignoreDependencyMap); err != nil {
 		return err
 	}
 	dependencyMap, err := GetDependencyMap(pkgFs, gcRootDir)
@@ -113,7 +117,7 @@ func getMainChartUpstreamOptions(pkgFs billy.Filesystem, gcRootDir string) (*opt
 }
 
 // LoadDependencies takes all existing subcharts in the package and loads them into the gcRootDir as dependencies
-func LoadDependencies(pkgFs billy.Filesystem, mainHelmChartPath string, gcRootDir string) error {
+func LoadDependencies(pkgFs billy.Filesystem, mainHelmChartPath string, gcRootDir string, ignoreDependencyMap map[string]bool) error {
 	// Get main chart options
 	mainChartUpstreamOpts, err := getMainChartUpstreamOptions(pkgFs, gcRootDir)
 	if err != nil {
@@ -123,6 +127,14 @@ func LoadDependencies(pkgFs billy.Filesystem, mainHelmChartPath string, gcRootDi
 	mainChart, err := helmLoader.Load(filesystem.GetAbsPath(pkgFs, mainHelmChartPath))
 	if err != nil {
 		return err
+	}
+	var numChartsRemoved int
+	for i, dependency := range mainChart.Metadata.Dependencies {
+		if ignoreDependencyMap[dependency.Name] {
+			// delete this dependency
+			mainChart.Metadata.Dependencies = append(mainChart.Metadata.Dependencies[:i-numChartsRemoved], mainChart.Metadata.Dependencies[i+1-numChartsRemoved:]...)
+			numChartsRemoved++
+		}
 	}
 	// Handle local chart archives first since version numbers don't make a difference
 	for _, dependency := range mainChart.Metadata.Dependencies {

--- a/pkg/charts/dependencies.go
+++ b/pkg/charts/dependencies.go
@@ -251,8 +251,11 @@ func UpdateHelmMetadataWithDependencies(fs billy.Filesystem, mainHelmChartPath s
 		return err
 	}
 	// Pick up all existing dependencies tracked by Helm by name
-	helmDependencyMap := make(map[string]*helmChart.Dependency, len(chart.Metadata.Dependencies))
+	helmDependencyMap := make(map[string]*helmChart.Dependency, len(dependencyMap))
 	for _, dependency := range chart.Metadata.Dependencies {
+		if _, ok := dependencyMap[dependency.Name]; !ok {
+			continue
+		}
 		helmDependencyMap[dependency.Name] = dependency
 	}
 	// Update the Repository for each dependency

--- a/pkg/charts/parse.go
+++ b/pkg/charts/parse.go
@@ -154,6 +154,7 @@ func GetChartFromOptions(opt options.ChartOptions) (Chart, error) {
 		WorkingDir:         workingDir,
 		Upstream:           upstream,
 		IgnoreDependencies: opt.IgnoreDependencies,
+		ReplacePaths:       opt.ReplacePaths,
 	}, nil
 }
 
@@ -175,6 +176,7 @@ func GetAdditionalChartFromOptions(opt options.AdditionalChartOptions) (Addition
 	a = AdditionalChart{
 		WorkingDir:         opt.WorkingDir,
 		IgnoreDependencies: opt.IgnoreDependencies,
+		ReplacePaths:       opt.ReplacePaths,
 	}
 	if opt.UpstreamOptions != nil {
 		upstream, err := GetUpstream(*opt.UpstreamOptions)

--- a/pkg/charts/parse.go
+++ b/pkg/charts/parse.go
@@ -151,8 +151,9 @@ func GetChartFromOptions(opt options.ChartOptions) (Chart, error) {
 		workingDir = "charts"
 	}
 	return Chart{
-		WorkingDir: workingDir,
-		Upstream:   upstream,
+		WorkingDir:         workingDir,
+		Upstream:           upstream,
+		IgnoreDependencies: opt.IgnoreDependencies,
 	}, nil
 }
 
@@ -172,7 +173,8 @@ func GetAdditionalChartFromOptions(opt options.AdditionalChartOptions) (Addition
 		return a, fmt.Errorf("working directory for an additional chart cannot be charts")
 	}
 	a = AdditionalChart{
-		WorkingDir: opt.WorkingDir,
+		WorkingDir:         opt.WorkingDir,
+		IgnoreDependencies: opt.IgnoreDependencies,
 	}
 	if opt.UpstreamOptions != nil {
 		upstream, err := GetUpstream(*opt.UpstreamOptions)

--- a/pkg/options/additionalchart.go
+++ b/pkg/options/additionalchart.go
@@ -10,6 +10,8 @@ type AdditionalChartOptions struct {
 	CRDChartOptions *CRDChartOptions `yaml:"crdOptions,omitempty"`
 	// IgnoreDependencies drops certain dependencies from the list that is parsed from upstream
 	IgnoreDependencies []string `yaml:"ignoreDependencies"`
+	// ReplacePaths marks paths as those that should be replaced instead of patches. Consequently, these paths will exist in both generated-changes/excludes and generated-changes/overlay
+	ReplacePaths []string `yaml:"replacePaths"`
 }
 
 // CRDChartOptions represent any options that are configurable for CRD charts

--- a/pkg/options/additionalchart.go
+++ b/pkg/options/additionalchart.go
@@ -8,6 +8,8 @@ type AdditionalChartOptions struct {
 	UpstreamOptions *UpstreamOptions `yaml:"upstreamOptions,omitempty"`
 	// CRDChartOptions is any options provided on how to generate a CRD chart. It is mutually exclusive with UpstreamOptions
 	CRDChartOptions *CRDChartOptions `yaml:"crdOptions,omitempty"`
+	// IgnoreDependencies drops certain dependencies from the list that is parsed from upstream
+	IgnoreDependencies []string `yaml:"ignoreDependencies"`
 }
 
 // CRDChartOptions represent any options that are configurable for CRD charts

--- a/pkg/options/chart.go
+++ b/pkg/options/chart.go
@@ -18,6 +18,8 @@ type ChartOptions struct {
 	UpstreamOptions UpstreamOptions `yaml:",inline"`
 	// IgnoreDependencies drops certain dependencies from the list that is parsed from upstream
 	IgnoreDependencies []string `yaml:"ignoreDependencies"`
+	// ReplacePaths marks paths as those that should be replaced instead of patches. Consequently, these paths will exist in both generated-changes/excludes and generated-changes/overlay
+	ReplacePaths []string `yaml:"replacePaths"`
 }
 
 // UpstreamOptions represents the options presented to users to define where the upstream Helm chart is located

--- a/pkg/options/chart.go
+++ b/pkg/options/chart.go
@@ -16,6 +16,8 @@ type ChartOptions struct {
 	WorkingDir string `yaml:"workingDir" default:"charts"`
 	// UpstreamOptions is any options provided on how to get this chart from upstream
 	UpstreamOptions UpstreamOptions `yaml:",inline"`
+	// IgnoreDependencies drops certain dependencies from the list that is parsed from upstream
+	IgnoreDependencies []string `yaml:"ignoreDependencies"`
 }
 
 // UpstreamOptions represents the options presented to users to define where the upstream Helm chart is located


### PR DESCRIPTION
ignoreDependencies supports the ability to be able to drop dependencies grabbed by upstream in case a chart owner wants to omit such dependencies. For example, for Project Monitoring V2 we would like to omit all exporter charts without storing a ton of patches and exclude files.

replacePaths supports the ability to mark particular paths in a chart as ones that should **not** be stored under `generated-changes/patches` but instead be stored in both `generated-changes/overlay` and `generated-changes/exclude`. While this doesn't change any functionality per-say, it makes the contents of the generated-changes directory more readable.