### PR TITLE
Add regsync make target command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2
+	github.com/hashicorp/go-version v1.6.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/urfave/cli v1.22.9
 	golang.org/x/exp v0.0.0-20221208152030-732eee02a75a
@@ -71,7 +72,6 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
-	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
@@ -147,7 +147,7 @@ require (
 	k8s.io/apimachinery v0.24.3 // indirect
 	k8s.io/apiserver v0.24.2 // indirect
 	k8s.io/cli-runtime v0.24.2 // indirect
-	k8s.io/client-go v0.24.2 // indirect
+	k8s.io/client-go v12.0.0+incompatible // indirect
 	k8s.io/component-base v0.24.2 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/charts-build-scripts/pkg/options"
 	"github.com/rancher/charts-build-scripts/pkg/path"
 	"github.com/rancher/charts-build-scripts/pkg/puller"
+	"github.com/rancher/charts-build-scripts/pkg/regsync"
 	"github.com/rancher/charts-build-scripts/pkg/repository"
 	"github.com/rancher/charts-build-scripts/pkg/standardize"
 	"github.com/rancher/charts-build-scripts/pkg/update"
@@ -141,6 +142,11 @@ func main() {
 			Action: generateCharts,
 			Before: setupCache,
 			Flags:  []cli.Flag{packageFlag, configFlag, cacheFlag},
+		},
+		{
+			Name:   "regsync",
+			Usage:  "Create a regsync config file containing all images used for the particular Rancher version",
+			Action: generateRegSyncConfigFile,
 		},
 		{
 			Name:   "index",
@@ -278,6 +284,12 @@ func generateCharts(c *cli.Context) {
 		if err := p.GenerateCharts(chartsScriptOptions.OmitBuildMetadataOnExport); err != nil {
 			logrus.Fatal(err)
 		}
+	}
+}
+
+func generateRegSyncConfigFile(c *cli.Context) {
+	if err := regsync.GenerateConfigFile(); err != nil {
+		logrus.Fatal(err)
 	}
 }
 

--- a/pkg/regsync/generateconfig.go
+++ b/pkg/regsync/generateconfig.go
@@ -1,0 +1,194 @@
+package regsync
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"golang.org/x/exp/slices"
+	"gopkg.in/yaml.v2"
+)
+
+// GenerateConfigFile creates a regsync config file out of the current branch.
+func GenerateConfigFile() error {
+	imageTagMap := make(map[string][]string)
+
+	err := walkAssetsFolder(imageTagMap)
+	if err != nil {
+		return err
+	}
+
+	// Create the regsync config file
+	err = createRegSyncConfigFile(imageTagMap)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// walkAssetsFolder walks over the assets folder, untars files, stores the values.yaml content
+// into a map and then iterates over the map to collect the image repo and tag values
+// into another map.
+func walkAssetsFolder(imageTagMap map[string][]string) error {
+	// Walk through the assets folder of the repo
+	filepath.Walk("./assets/", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("error occurred while walking over the assets directory file %s:%s", path, err)
+		}
+
+		// Check if the file name ends with tgz ? since we only care about them
+		// to untar them and check for values.yaml files.
+		if strings.HasSuffix(info.Name(), ".tgz") {
+			valuesYamlMaps, err := decodeValuesFilesInTgz(path)
+			if err != nil {
+				return fmt.Errorf("error occurred while getting values yaml into map in %s:%s", path, err)
+			}
+
+			// There can be multiple values yaml files for single chart. So, making a for loop.
+			for _, valuesYaml := range valuesYamlMaps {
+				// Collecting all iamges with the following notation in the values yaml files
+				// reposoitory :
+				// tag :
+				walkMap(valuesYaml, func(inputMap map[interface{}]interface{}) {
+					repository, ok := inputMap["repository"].(string)
+					if !ok {
+						return
+					}
+					// No string type assertion because some charts have float typed image tags
+					tag, ok := inputMap["tag"]
+					if !ok {
+						return
+					}
+
+					// If the tag is already found, we don't append it again
+					found := slices.Contains(imageTagMap[repository], fmt.Sprintf("%v", tag))
+					if !found {
+						imageTagMap[repository] = append(imageTagMap[repository], fmt.Sprintf("%v", tag))
+					}
+				})
+			}
+		}
+		return nil
+	})
+
+	return nil
+}
+
+// createRegSyncConfigFile create the regsync configuration file from the image list map provided.
+func createRegSyncConfigFile(imageTagMap map[string][]string) error {
+	filename := "regsync.yaml"
+
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	fmt.Fprintln(file, `---
+version: 1
+creds:
+- registry: '{{ env "REGISTRY_ENDPOINT" }}'
+  user: '{{ env "REGISTRY_USERNAME" }}'
+  pass: '{{ env "REGISTRY_PASSWORD" }}'
+defaults:
+  mediaTypes:
+  - application/vnd.docker.distribution.manifest.v2+json
+  - application/vnd.docker.distribution.manifest.list.v2+json
+  - application/vnd.oci.image.manifest.v1+json
+  - application/vnd.oci.image.index.v1+json
+sync:`)
+
+	// We collect all repos and then sort them so there is consistency
+	// in the update of the regsync file always. This has to be done
+	// since golang range iterates over a map in a randomised manner.
+	repositories := make([]string, 0)
+	for repo := range imageTagMap {
+		repositories = append(repositories, repo)
+	}
+	sort.Strings(repositories)
+
+	for _, repo := range repositories {
+		fmt.Fprintf(file, "%s%s\n", "- source: docker.io/", repo)
+		fmt.Fprintf(file, `  target: '{{ env "REGISTRY_ENDPOINT" }}/%s'`, repo)
+		fmt.Fprintln(file)
+		fmt.Fprintln(file, "  type: repository")
+		fmt.Fprintln(file, "  tags:")
+		fmt.Fprintln(file, "    allow:")
+
+		for _, imageTag := range imageTagMap[repo] {
+			fmt.Fprintf(file, "    - %s\n", imageTag)
+		}
+	}
+
+	return nil
+}
+
+// decodeValueFilesInTgz reads tarball in tgzPath and returns a slice of values corresponding to values.yaml files found inside of it.
+func decodeValuesFilesInTgz(tgzPath string) ([]map[interface{}]interface{}, error) {
+	tgz, err := os.Open(tgzPath)
+	if err != nil {
+		return nil, err
+	}
+	defer tgz.Close()
+	gzr, err := gzip.NewReader(tgz)
+	if err != nil {
+		return nil, err
+	}
+	defer gzr.Close()
+	tr := tar.NewReader(gzr)
+	var valuesSlice []map[interface{}]interface{}
+	for {
+		header, err := tr.Next()
+		switch {
+		case err == io.EOF:
+			return valuesSlice, nil
+		case err != nil:
+			return nil, err
+		case header.Typeflag == tar.TypeReg && isValuesFile(header.Name):
+			var values map[interface{}]interface{}
+			if err := decodeYAMLFile(tr, &values); err != nil {
+				return nil, err
+			}
+			valuesSlice = append(valuesSlice, values)
+		default:
+			continue
+		}
+	}
+}
+
+// decodeYAMLFile unmarshals the values into the target interface
+func decodeYAMLFile(r io.Reader, target interface{}) error {
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal(data, target)
+}
+
+// isValuesFile checks if the current file is helm values.yaml or not
+func isValuesFile(path string) bool {
+	basename := filepath.Base(path)
+	return basename == "values.yaml" || basename == "values.yml"
+}
+
+// walkMap walks inputMap and calls the callback function on all map type nodes including the root node.
+func walkMap(inputMap interface{}, callback func(map[interface{}]interface{})) {
+	switch data := inputMap.(type) {
+	case map[interface{}]interface{}:
+		callback(data)
+		for _, value := range data {
+			walkMap(value, callback)
+		}
+	case []interface{}:
+		for _, elem := range data {
+			walkMap(elem, callback)
+		}
+	}
+}


### PR DESCRIPTION
JIRA Issue - https://jira.suse.com/browse/SURE-5868

Security Team Review Issue - https://github.com/rancher/security-team/issues/227

Implemented Solution 3 here - https://confluence.suse.com/display/EN/Rancher+Prime+Image+Publishing+for+OOB+Chart+Releases

TLDR 

- This PR creates a make target when run against rancher/charts repository like `make patch`, will create a regsync config yaml for the EIO team to consume. 
- This updated file will be committed along the OOB release PR. 
- The EIO team will regularly check for this file and sync to its Prime registry.
