### PR TITLE
Fixing asset validation list

### DIFF
--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -176,7 +176,7 @@ func CompareGeneratedAssets(repoFs billy.Filesystem, u options.UpstreamOptions, 
 		}
 		// Chart was modified in local and is not tracked by release.yaml
 		logrus.Infof("%s/%s was modified", chart.Metadata.Name, chart.Metadata.Version)
-		response.ModifiedPostRelease = response.RemovedPostRelease.Append(chart.Metadata.Name, chart.Metadata.Version)
+		response.ModifiedPostRelease = response.ModifiedPostRelease.Append(chart.Metadata.Name, chart.Metadata.Version)
 		return copyAndUnzip(repoFs, upstreamPath, localPath)
 	}
 


### PR DESCRIPTION
When logging discrepancies, the code prints the following lists:

- UntrackedInRelease
- RemovedPostRelease
- ModifiedPostRelease

I noticed that RemovedPostRelease and ModifiedPostRelease were always the same, in case of an error. This happened because ModifiedPostRelease was being assigned the value of RemovedPostRelease. If I remove chart A and modify chart B, RemovedPostRelease should contain only chart A, and ModifiedPostRelease should contain only chart B. That wasn't the actual result. The actual result was both lists containing both charts. This modification fixes it.