### PR TITLE
Checking if container images belongs to rancher namespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/charts-build-scripts/pkg/charts"
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
 	"github.com/rancher/charts-build-scripts/pkg/helm"
+	"github.com/rancher/charts-build-scripts/pkg/images"
 	"github.com/rancher/charts-build-scripts/pkg/options"
 	"github.com/rancher/charts-build-scripts/pkg/path"
 	"github.com/rancher/charts-build-scripts/pkg/puller"
@@ -218,6 +219,11 @@ func main() {
 					Value:       "master",
 				},
 			},
+		},
+		{
+			Name:   "check-images",
+			Usage:  "Checks all container images used in the charts repository",
+			Action: checkImages,
 		},
 	}
 
@@ -478,4 +484,10 @@ func getGitInfo() (*git.Repository, *git.Worktree, git.Status) {
 		logrus.Fatal(err)
 	}
 	return repo, wt, status
+}
+
+func checkImages(c *cli.Context) {
+	if err := images.CheckImages(); err != nil {
+		logrus.Fatal(err)
+	}
 }

--- a/pkg/images/checkImages.go
+++ b/pkg/images/checkImages.go
@@ -1,0 +1,5 @@
+package images
+
+func CheckImages() error {
+	return nil
+}

--- a/pkg/images/checkImages.go
+++ b/pkg/images/checkImages.go
@@ -1,5 +1,37 @@
 package images
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rancher/charts-build-scripts/pkg/regsync"
+)
+
+// CheckImages checks if all container images used in charts belong to the rancher namespace
 func CheckImages() error {
+	// Get required tags for all images
+	imageTagMap, err := regsync.GenerateImageTagMap()
+	if err != nil {
+		return err
+	}
+
+	// Check if there's any image outside the rncher namespace
+	nonMatchingImages := checkPattern(imageTagMap)
+	if len(nonMatchingImages) > 0 {
+		return fmt.Errorf("found images outside the rancher namespace: %v", nonMatchingImages)
+	}
 	return nil
+}
+
+// checkPattern checks for pattern "rancher/*" in an array and returns items that do not match.
+func checkPattern(imageTagMap map[string][]string) []string {
+	nonMatchingImages := make([]string, 0)
+
+	for image := range imageTagMap {
+		if !strings.HasPrefix(image, "rancher/") {
+			nonMatchingImages = append(nonMatchingImages, image)
+		}
+	}
+
+	return nonMatchingImages
 }

--- a/pkg/regsync/generateImageTagMap.go
+++ b/pkg/regsync/generateImageTagMap.go
@@ -1,0 +1,13 @@
+package regsync
+
+// GenerateImageTagMap returns a map of container images and their tags
+func GenerateImageTagMap() (map[string][]string, error) {
+	imageTagMap := make(map[string][]string)
+
+	err := walkAssetsFolder(imageTagMap)
+	if err != nil {
+		return imageTagMap, err
+	}
+
+	return imageTagMap, nil
+}


### PR DESCRIPTION
Adds a new command to check if the images in the charts repository belong to the rancher namespace.