### PR TITLE
Adding token to Docker Hub requests if credentials are set

### DIFF
--- a/pkg/rest/head.go
+++ b/pkg/rest/head.go
@@ -12,7 +12,7 @@ import (
 const maxRetries = 5
 
 // Head sends a HEAD request to the given URL and returns an error if the request fails
-func Head(url string) error {
+func Head(url, token string) error {
 
 	// Retry until max retries reached
 	for retries := 0; retries <= maxRetries; retries++ {
@@ -21,6 +21,11 @@ func Head(url string) error {
 		req, err := http.NewRequest("HEAD", url, nil)
 		if err != nil {
 			return fmt.Errorf("error creating the HEAD request: %v", err)
+		}
+
+		// Add the authorization header if a token is provided
+		if token != "" {
+			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 		}
 
 		// Create a new HTTP client

--- a/pkg/rest/post.go
+++ b/pkg/rest/post.go
@@ -1,0 +1,52 @@
+package rest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Post sends a POST request to the given URL with the given body and decodes the response into the given response model.
+func Post(url string, body, responseModel any) error {
+
+	// Marshal the body
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("error marshalling the body: %v", err)
+	}
+
+	// Create a new POST request
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return fmt.Errorf("error creating the POST request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	// Create a new HTTP client
+	client := &http.Client{
+		Timeout: time.Second * 2,
+	}
+
+	// Send the request
+	response, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error sending the POST request: %v", err)
+	}
+	defer response.Body.Close()
+
+	// Check the status code
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("received unexpected status code %d with message: %v", response.StatusCode, response.Body)
+	}
+
+	// Decode the response body
+	err = json.NewDecoder(response.Body).Decode(responseModel)
+	if err != nil {
+		return fmt.Errorf("error decoding the response body: %v", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
- Retrieve token from Docker Hub if credential environment variables are set
- Will not fail if credentials are unset or if fails to retrieve a token. Instead, will send unauthenticated requests to check tags
- Execution time is improved from 4'30" to 2'10" if credentials are set