### PR TITLE
Improving RC image check to check only images being used in charts that are on release.yaml

### DIFF
--- a/main.go
+++ b/main.go
@@ -509,6 +509,8 @@ func checkRCTagsAndVersions(c *cli.Context) {
 	if len(rcChartVersionMap) > 0 || len(rcImageTagMap) > 0 {
 		logrus.Errorf("found images with RC tags: %v", rcImageTagMap)
 		logrus.Errorf("found charts with RC version: %v", rcChartVersionMap)
-		logrus.Fatalf("rc check has failed")
+		logrus.Fatal("RC check has failed")
 	}
+
+	logrus.Info("RC check has succeeded")
 }

--- a/pkg/images/checkRCTags.go
+++ b/pkg/images/checkRCTags.go
@@ -1,21 +1,32 @@
 package images
 
 import (
+	"os"
 	"strings"
 
+	"github.com/rancher/charts-build-scripts/pkg/filesystem"
+	"github.com/rancher/charts-build-scripts/pkg/options"
 	"github.com/rancher/charts-build-scripts/pkg/regsync"
 	"github.com/sirupsen/logrus"
 )
 
 // CheckRCTags checks for any images that have RC tags
 func CheckRCTags() map[string][]string {
+
+	// Get the release options from the release.yaml file
+	releaseOptions := getReleaseOptions()
+
+	logrus.Infof("Checking for RC tags in charts: %v", releaseOptions)
+
 	rcImageTagMap := make(map[string][]string, 0)
 
 	// Get required tags for all images
-	imageTagMap, err := regsync.GenerateImageTagMap()
+	imageTagMap, err := regsync.GenerateFilteredImageTagMap(releaseOptions)
 	if err != nil {
 		logrus.Fatal("failed to generate image tag map: ", err)
 	}
+
+	logrus.Infof("Checking for RC tags in all collected images")
 
 	// Grab all images that contain RC tags
 	for image := range imageTagMap {
@@ -27,4 +38,24 @@ func CheckRCTags() map[string][]string {
 	}
 
 	return rcImageTagMap
+}
+
+// getReleaseOptions returns the release options from the release.yaml file
+func getReleaseOptions() options.ReleaseOptions {
+	// Get the current working directory
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		logrus.Fatalf("Unable to get current working directory: %s", err)
+	}
+
+	// Get the filesystem on the repo root
+	repoFs := filesystem.GetFilesystem(repoRoot)
+
+	// Load the release options from the release.yaml file
+	releaseOptions, err := options.LoadReleaseOptionsFromFile(repoFs, "release.yaml")
+	if err != nil {
+		logrus.Fatalf("Unable to unmarshall release.yaml: %s", err)
+	}
+
+	return releaseOptions
 }

--- a/pkg/regsync/generateFilteredImageTagMap.go
+++ b/pkg/regsync/generateFilteredImageTagMap.go
@@ -1,0 +1,131 @@
+package regsync
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
+)
+
+// GenerateFilteredImageTagMap returns a map of container images and their tags
+func GenerateFilteredImageTagMap(filter map[string][]string) (map[string][]string, error) {
+	imageTagMap := make(map[string][]string)
+
+	err := walkFilteredAssetsFolder(imageTagMap, filter)
+	if err != nil {
+		return imageTagMap, err
+	}
+
+	return imageTagMap, nil
+}
+
+// walkAssetsFolder walks over the assets folder, untars files if their name matches one of the filter values,
+// stores the values.yaml content into a map and then iterates over the map to collect the image repo and tag values
+// into another map.
+func walkFilteredAssetsFolder(imageTagMap, filter map[string][]string) error {
+
+	assetErrorMap := make(map[string]error)
+	// Walk through the assets folder of the repo
+	filepath.Walk("./assets/", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("error occurred while walking over the assets directory file %s:%s", path, err)
+		}
+
+		// Get the file name
+		filename := info.Name()
+
+		// Check if the file name ends with tgz ? since we only care about them
+		// to untar them and check for values.yaml files.
+		if strings.HasSuffix(filename, ".tgz") {
+			valuesYamlMaps, err := decodeValuesFilesInTgz(path)
+			if err != nil {
+				assetErrorMap[filename] = err
+				return fmt.Errorf("error occurred while getting values yaml into map in %s:%s", path, err)
+			}
+
+			// Get the chart name and version from the filename
+			chartName, chartVersion, err := getChartNameAndVersion(filename)
+			if err != nil {
+				assetErrorMap[filename] = err
+				return err
+			}
+
+			// Iterate over the filter map to check if the chart name and version are in the filter map
+			for chart, versions := range filter {
+				if strings.Compare(chartName, chart) == 0 {
+					for _, version := range versions {
+						if strings.Compare(chartVersion, version) == 0 {
+
+							logrus.Infof("collecting images and tags for chart %s version %s", chartName, chartVersion)
+
+							// There can be multiple values yaml files for single chart. So, making a for loop.
+							for _, valuesYaml := range valuesYamlMaps {
+
+								// Collecting all images with the following notation in the values yaml files
+								// reposoitory :
+								// tag :
+								walkMap(valuesYaml, func(inputMap map[interface{}]interface{}) {
+									repository, ok := inputMap["repository"].(string)
+									if !ok {
+										return
+									}
+									// No string type assertion because some charts have float typed image tags
+									tag, ok := inputMap["tag"]
+									if !ok {
+										return
+									}
+
+									// If the chart & tag are in the ignore charttags map, we ignore them
+									for ignoreChartName, ignoreTag := range chartsToIgnoreTags {
+										// find the chart name using the path variable
+										if strings.Contains(path, fmt.Sprintf("/%s/", ignoreChartName)) {
+											if tag == ignoreTag {
+												return
+											}
+										}
+									}
+
+									// If the tag is already found, we don't append it again
+									found := slices.Contains(imageTagMap[repository], fmt.Sprintf("%v", tag))
+									if !found {
+										imageTagMap[repository] = append(imageTagMap[repository], fmt.Sprintf("%v", tag))
+									}
+								})
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return nil
+	})
+
+	if len(assetErrorMap) > 0 {
+		return fmt.Errorf("error occurred while walking over the assets directory: %v", assetErrorMap)
+	}
+
+	return nil
+}
+
+// getChartNameAndVersion returns the chart name and version from the filename
+func getChartNameAndVersion(filename string) (string, string, error) {
+	// Remove the .tgz suffix
+	if strings.HasSuffix(filename, ".tgz") {
+		filename = filename[:len(filename)-4]
+	} else {
+		return "", "", fmt.Errorf("file does not have a .tgz suffix")
+	}
+
+	// Find the first digit from the left
+	for i := 0; i < len(filename); i++ {
+		if unicode.IsDigit(rune(filename[i+1])) {
+			return filename[:i], filename[i+1:], nil
+		}
+	}
+	return "", "", fmt.Errorf("could not extract details from filename")
+}


### PR DESCRIPTION
- Improving logs on checking RC tags and versions
- Creating a public method in the regsync package to grab images and tags with filtering capabilities
- Checking RC tags only in charts that are on release.yaml