### PR TITLE
add support for oci charts

### DIFF
--- a/pkg/charts/parse.go
+++ b/pkg/charts/parse.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/charts-build-scripts/pkg/path"
 	"github.com/rancher/charts-build-scripts/pkg/puller"
 	"github.com/sirupsen/logrus"
+	"helm.sh/helm/v3/pkg/registry"
 )
 
 // GetPackages returns all packages found within the repository. If there is a specific package provided, it will return just that Package in the list
@@ -223,6 +224,12 @@ func GetUpstream(opt options.UpstreamOptions) (puller.Puller, error) {
 		}
 		if opt.Subdirectory != nil {
 			upstream.Subdirectory = opt.Subdirectory
+		}
+		return upstream, nil
+	}
+	if registry.IsOCI(opt.URL) {
+		upstream := puller.Registry{
+			URL: opt.URL,
 		}
 		return upstream, nil
 	}

--- a/pkg/puller/oci.go
+++ b/pkg/puller/oci.go
@@ -1,0 +1,61 @@
+package puller
+
+import (
+	"os"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/rancher/charts-build-scripts/pkg/filesystem"
+	"github.com/rancher/charts-build-scripts/pkg/options"
+	"github.com/sirupsen/logrus"
+	"helm.sh/helm/v3/pkg/getter"
+)
+
+type Registry struct {
+	// URL represents the link to the chart registry including the chart version
+	URL string `yaml:"url"`
+}
+
+func (r Registry) Pull(rootFs, fs billy.Filesystem, path string) error {
+	logrus.Infof("Pulling %s from upstream into %s", r.URL, path)
+
+	getter, err := getter.NewOCIGetter()
+	if err != nil {
+		return err
+	}
+
+	buffer, err := getter.Get(r.URL)
+	if err != nil {
+		return err
+	}
+
+	tgz, err := filesystem.CreateFileAndDirs(fs, chartArchiveFilepath)
+	if err != nil {
+		return err
+	}
+	defer fs.Remove(chartArchiveFilepath)
+
+	if _, err := tgz.Write(buffer.Bytes()); err != nil {
+		return err
+	}
+
+	if err := fs.MkdirAll(path, os.ModePerm); err != nil {
+		return err
+	}
+	defer filesystem.PruneEmptyDirsInPath(fs, path)
+
+	if err := filesystem.UnarchiveTgz(fs, chartArchiveFilepath, "", path, true); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r Registry) GetOptions() options.UpstreamOptions {
+	return options.UpstreamOptions{
+		URL: r.URL,
+	}
+}
+
+func (r Registry) IsWithinPackage() bool {
+	return false
+}


### PR DESCRIPTION
Issues https://github.com/rancher/rancher/issues/43714

Add support for OCI chart registries, in support of upgrading rancher-logging upstream to kube-logging 4.4.0