### PR TITLE
Download icons locally when running make charts

### DIFF
--- a/main.go
+++ b/main.go
@@ -290,9 +290,13 @@ func generateCharts(c *cli.Context) {
 		logrus.Infof("No packages found.")
 		return
 	}
+	validateOnly := false
+	if c.Command.Name == "validate" {
+		validateOnly = true
+	}
 	chartsScriptOptions := parseScriptOptions()
 	for _, p := range packages {
-		if err := p.GenerateCharts(chartsScriptOptions.OmitBuildMetadataOnExport); err != nil {
+		if err := p.GenerateCharts(chartsScriptOptions.OmitBuildMetadataOnExport, validateOnly); err != nil {
 			logrus.Fatal(err)
 		}
 	}

--- a/pkg/charts/additionalchart.go
+++ b/pkg/charts/additionalchart.go
@@ -214,11 +214,11 @@ func (c *AdditionalChart) GeneratePatch(rootFs, pkgFs billy.Filesystem) error {
 }
 
 // GenerateChart generates the chart and stores it in the assets and charts directory
-func (c *AdditionalChart) GenerateChart(rootFs, pkgFs billy.Filesystem, packageVersion *int, version *semver.Version, omitBuildMetadataOnExport bool) error {
+func (c *AdditionalChart) GenerateChart(rootFs, pkgFs billy.Filesystem, packageVersion *int, version *semver.Version, omitBuildMetadataOnExport, validateOnly bool) error {
 	if c.upstreamChartVersion == nil {
 		return fmt.Errorf("cannot generate chart since it has never been prepared: upstreamChartVersion is not set")
 	}
-	if err := helm.ExportHelmChart(rootFs, pkgFs, c.WorkingDir, packageVersion, version, *c.upstreamChartVersion, omitBuildMetadataOnExport); err != nil {
+	if err := helm.ExportHelmChart(rootFs, pkgFs, c.WorkingDir, packageVersion, version, *c.upstreamChartVersion, omitBuildMetadataOnExport, validateOnly); err != nil {
 		return fmt.Errorf("encountered error while trying to export Helm chart for %s: %s", c.WorkingDir, err)
 	}
 	return nil

--- a/pkg/charts/chart.go
+++ b/pkg/charts/chart.go
@@ -103,11 +103,11 @@ func (c *Chart) GeneratePatch(rootFs, pkgFs billy.Filesystem) error {
 }
 
 // GenerateChart generates the chart and stores it in the assets and charts directory
-func (c *Chart) GenerateChart(rootFs, pkgFs billy.Filesystem, packageVersion *int, version *semver.Version, omitBuildMetadataOnExport bool) error {
+func (c *Chart) GenerateChart(rootFs, pkgFs billy.Filesystem, packageVersion *int, version *semver.Version, omitBuildMetadataOnExport, validateOnly bool) error {
 	if c.upstreamChartVersion == nil {
 		return fmt.Errorf("cannot generate chart since it has never been prepared: upstreamChartVersion is not set")
 	}
-	if err := helm.ExportHelmChart(rootFs, pkgFs, c.WorkingDir, packageVersion, version, *c.upstreamChartVersion, omitBuildMetadataOnExport); err != nil {
+	if err := helm.ExportHelmChart(rootFs, pkgFs, c.WorkingDir, packageVersion, version, *c.upstreamChartVersion, omitBuildMetadataOnExport, validateOnly); err != nil {
 		return fmt.Errorf("encountered error while trying to export Helm chart for %s: %s", c.WorkingDir, err)
 	}
 	return nil

--- a/pkg/charts/package.go
+++ b/pkg/charts/package.go
@@ -86,7 +86,7 @@ func (p *Package) GeneratePatch() error {
 }
 
 // GenerateCharts creates Helm chart archives for each chart after preparing it
-func (p *Package) GenerateCharts(omitBuildMetadataOnExport bool) error {
+func (p *Package) GenerateCharts(omitBuildMetadataOnExport bool, validateOnly bool) error {
 	if p.DoNotRelease {
 		logrus.Infof("Skipping package marked doNotRelease")
 		return nil
@@ -95,12 +95,12 @@ func (p *Package) GenerateCharts(omitBuildMetadataOnExport bool) error {
 		return fmt.Errorf("encountered error while trying to prepare package: %s", err)
 	}
 	// Add PackageVersion to format
-	err := p.Chart.GenerateChart(p.rootFs, p.fs, p.PackageVersion, p.Version, omitBuildMetadataOnExport)
+	err := p.Chart.GenerateChart(p.rootFs, p.fs, p.PackageVersion, p.Version, omitBuildMetadataOnExport, validateOnly)
 	if err != nil {
 		return fmt.Errorf("encountered error while exporting main chart: %s", err)
 	}
 	for _, additionalChart := range p.AdditionalCharts {
-		err = additionalChart.GenerateChart(p.rootFs, p.fs, p.PackageVersion, p.Version, omitBuildMetadataOnExport)
+		err = additionalChart.GenerateChart(p.rootFs, p.fs, p.PackageVersion, p.Version, omitBuildMetadataOnExport, validateOnly)
 		if err != nil {
 			return fmt.Errorf("encountered error while exporting %s: %s", additionalChart.WorkingDir, err)
 		}

--- a/pkg/icons/icons.go
+++ b/pkg/icons/icons.go
@@ -1,0 +1,45 @@
+package icons
+
+import (
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+
+	"github.com/rancher/charts-build-scripts/pkg/path"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/sirupsen/logrus"
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+// Download receives a chart metadata and the filesystem pointing to the root of the project.
+// From the metadata, gets the icon and name of the chart.
+// It downloads the icon, infers the type using the content-type header from the response
+// and saves the file locally to path.RepositoryLogosDir using the name of the chart as the file name.
+func Download(rootFs billy.Filesystem, metadata *chart.Metadata) (string, error) {
+	icon, err := http.Get(metadata.Icon)
+	if err != nil {
+		logrus.Errorf(err.Error())
+		return "", fmt.Errorf("err: %w", err)
+	}
+
+	byType, err := mime.ExtensionsByType(icon.Header.Get("Content-Type"))
+	if err != nil || len(byType) == 0 || icon.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("invalid icon")
+	}
+	path := fmt.Sprintf("%s/%s%s", path.RepositoryLogosDir, metadata.Name, byType[0])
+	create, err := rootFs.Create(path)
+	if err != nil {
+		logrus.Errorf(err.Error())
+		return "", fmt.Errorf("err: %w", err)
+	}
+	defer create.Close()
+	_, err = io.Copy(create, icon.Body)
+	defer icon.Body.Close()
+	if err != nil {
+		logrus.Errorf(err.Error())
+		return "", fmt.Errorf("err: %w", err)
+	}
+	return path, nil
+}

--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -46,4 +46,7 @@ const (
 
 	// DefaultCachePath represents the default place to put a cache on pulled values
 	DefaultCachePath = ".charts-build-scripts/.cache"
+
+	// RepositoryLogosDir is a directory on your Staging/Live branch that contains the files with the logos of each chart
+	RepositoryLogosDir = "assets/logos"
 )


### PR DESCRIPTION
When running the `make charts` command, it will check if the icon is pointing to a HTTP URL, and if so, download it and change the `Chart.yaml` to generated from the packages folder to point to it