### PR TITLE
Adds job to test curren pull request code against charts active branches

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,6 +1,7 @@
-name: CI-pullrequest
+name: Pull-Request
 
-on: [pull_request]
+on:
+  pull_request:
 
 jobs:
   build:
@@ -11,3 +12,62 @@ jobs:
       - uses: actions/checkout@v1
       - name: Run CI
         run: dapper ci
+
+  build-binary:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout 
+      uses: actions/checkout@v3
+
+    - name: Checkout Pull-Request
+      run: gh pr checkout ${{ github.event.pull_request.number }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+
+    - name: Build binaries
+      env:
+        CROSS: false
+      run: make build
+
+    - name: Upload Binary
+      uses: actions/upload-artifact@v2
+      with:
+        name: built-binary
+        path: bin/charts-build-scripts
+
+  validate:
+    needs: build-binary
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: [dev-v2.9]
+    steps:
+    - name: Download Binary
+      uses: actions/download-artifact@v2
+      with:
+        name: built-binary
+        path: bin
+    
+    - name: Allow binary to execute
+      run: chmod +x bin/charts-build-scripts
+
+    - name: Checkout charts Repo
+      uses: actions/checkout@v3
+      with:
+        repository: rancher/charts
+        ref: ${{ matrix.branch }}
+        path: charts
+
+    - name: Run Validation
+      run: |
+        cd charts
+        ../bin/charts-build-scripts validate
+
+  delete-artifact:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+    - name: Delete Artifact
+      uses: geekyeggo/delete-artifact@v2
+      with:
+          name: built-binary


### PR DESCRIPTION
- Adds a job to build the binary using the PR code and uploads the binary as an artifact;
- Adds a job to run `make validate` on active branches of `rancher/charts` repository (currently supported branches are dev-v2.9 in the master branch of this repository)
- Adds a job to delete the artifact.