### PR TITLE
Running make validate only for default branch of rancher/charts repo

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -13,61 +13,24 @@ jobs:
       - name: Run CI
         run: dapper ci
 
-  build-binary:
+  build-validate:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout 
       uses: actions/checkout@v3
-
-    - name: Checkout Pull-Request
-      run: gh pr checkout ${{ github.event.pull_request.number }}
-      env:
-        GH_TOKEN: ${{ github.token }}
 
     - name: Build binaries
       env:
         CROSS: false
       run: make build
 
-    - name: Upload Binary
-      uses: actions/upload-artifact@v2
-      with:
-        name: built-binary
-        path: bin/charts-build-scripts
-
-  validate:
-    needs: build-binary
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        branch: [dev-v2.9]
-    steps:
-    - name: Download Binary
-      uses: actions/download-artifact@v2
-      with:
-        name: built-binary
-        path: bin
-    
-    - name: Allow binary to execute
-      run: chmod +x bin/charts-build-scripts
-
     - name: Checkout charts Repo
       uses: actions/checkout@v3
       with:
         repository: rancher/charts
-        ref: ${{ matrix.branch }}
         path: charts
 
     - name: Run Validation
       run: |
         cd charts
         ../bin/charts-build-scripts validate
-
-  delete-artifact:
-    needs: validate
-    runs-on: ubuntu-latest
-    steps:
-    - name: Delete Artifact
-      uses: geekyeggo/delete-artifact@v2
-      with:
-          name: built-binary


### PR DESCRIPTION
This pull request changes the previous approach to running `make validate` in all active branches to just the default one.

- Removed the artifact management steps as it is not necessary anymore.
- Merged the `validate` and `build` jobs into `build-validate`
- The `build-validate job` only checks out the default branch. Not specifying the `ref` argument in the `actions/checkout@v3` step causes the step to check out the default branch.