### PR TITLE
Support pulling crds from an upstream

### DIFF
--- a/pkg/charts/additionalchart.go
+++ b/pkg/charts/additionalchart.go
@@ -117,6 +117,13 @@ func (c *AdditionalChart) Prepare(rootFs, pkgFs billy.Filesystem, mainChartUpstr
 		if err != nil {
 			return fmt.Errorf("encountered error while trying to get the main chart's working directory: %s", err)
 		}
+		if c.Upstream != nil {
+			logrus.Infof("pulling CRD upstream")
+			u := *c.Upstream
+			if err := u.Pull(rootFs, pkgFs, filepath.Join(mainChartWorkingDir, path.ChartCRDDir)); err != nil {
+				return fmt.Errorf("encountered error while trying to pull upstream into %s: %s", mainChartWorkingDir, err)
+			}
+		}
 		exists, err := filesystem.PathExists(pkgFs, filepath.Join(mainChartWorkingDir, path.ChartCRDDir))
 		if err != nil {
 			return fmt.Errorf("encountered error while trying to check if %s exists: %s", filepath.Join(mainChartWorkingDir, path.ChartCRDDir), err)

--- a/pkg/charts/parse.go
+++ b/pkg/charts/parse.go
@@ -162,9 +162,6 @@ func GetChartFromOptions(opt options.ChartOptions) (Chart, error) {
 // GetAdditionalChartFromOptions returns an AdditionalChart based on the options provided
 func GetAdditionalChartFromOptions(opt options.AdditionalChartOptions) (AdditionalChart, error) {
 	var a AdditionalChart
-	if opt.UpstreamOptions != nil && opt.CRDChartOptions != nil {
-		return a, fmt.Errorf("invalid additional chart options provided: cannot define both UpstreamOptions and CRDChartOptions")
-	}
 	if opt.UpstreamOptions == nil && opt.CRDChartOptions == nil {
 		return a, fmt.Errorf("cannot parse additional chart options: you must either provide a URL (UpstreamOptions) or provide CRDChartOptions")
 	}

--- a/pkg/options/additionalchart.go
+++ b/pkg/options/additionalchart.go
@@ -4,9 +4,9 @@ package options
 type AdditionalChartOptions struct {
 	// WorkingDir is the working directory for this chart within packages/<package-name>
 	WorkingDir string `yaml:"workingDir"`
-	// UpstreamOptions is any options provided on how to get this chart from upstream. It is mutually exclusive with CRDChartOptions
+	// UpstreamOptions is any options provided on how to get this chart from upstream.
 	UpstreamOptions *UpstreamOptions `yaml:"upstreamOptions,omitempty"`
-	// CRDChartOptions is any options provided on how to generate a CRD chart. It is mutually exclusive with UpstreamOptions
+	// CRDChartOptions is any options provided on how to generate a CRD chart.
 	CRDChartOptions *CRDChartOptions `yaml:"crdOptions,omitempty"`
 	// IgnoreDependencies drops certain dependencies from the list that is parsed from upstream
 	IgnoreDependencies []string `yaml:"ignoreDependencies"`

--- a/templates/template/docs/packages.md
+++ b/templates/template/docs/packages.md
@@ -16,12 +16,10 @@ additionalCharts:
 # These contain other charts that you would like to package alongside this chart
 - workingDir: # same as above
   upstreamOptions:
-    # Mutually exclusive with crdOptions
     url: # same as above
     subdirectory: # optional, same as above
     commit: # optional, same as above
   crdOptions:
-    # Mutually exclusive with upstreamOptions
     templateDirectory: # A directory within packages/<package>/template that will contain a template for your CRD chart
     crdDirectory: # Where to place your CRDs within a CRD chart (e.g. crds for default charts)
     addCRDValidationToMainChart: # Whether to add additional validation to your main chart to check that the CRD chart is installed.


### PR DESCRIPTION
# Problem

While updating the upstream for `rancher-monitoring` chart, I found that the crd generation code is unable to work with the structure of `kube-prometheus-stack`. The `charts-build-scripts` expect crds to be stored in a `crds` directory at the chart root directory; however, `kube-prometheus-stack` has moved its crds into a [subchart](https://github.com/prometheus-community/helm-charts/tree/7c6906ca223344c06952007fda670c6c81e6d1da/charts/kube-prometheus-stack/charts/crds). This causes several problems for crd generation:

1. Since we clear the `charts` directory when loading dependencies, the upstream crd subchart is removed before the crd is generated, so we cannot simply support a user specified location to look for crds over the default `crds`.
2. The upstream crd subchart is poorly defined so that the version is `0.0.0` and does not match the real upstream version `57.0.3`, so we cannot simply manage a `rancher-monitoring-crd` since the `rancher-monitoring` and `rancher-monitoring-crd` charts will not have matching versions.
3. The current `additionalCharts` configuration validation code does not allow for specifying both `upstreamOptions` and `crdOptions` so we cannot pull from an upstream and then use the crd template.

# Solution

Allow for specifying both `upstreamOptions` to pull the crds directory, and `crdOptions` to use the crd template.

fixes #13 
unblocks [#44614](https://github.com/rancher/rancher/issues/44614)