### PR TITLE
Make CRDDirectory and UseTarArchive mutually exclusive

### DIFF
--- a/pkg/charts/additionalchart.go
+++ b/pkg/charts/additionalchart.go
@@ -89,10 +89,10 @@ func (c *AdditionalChart) RevertMainChanges(pkgFs billy.Filesystem) error {
 	}
 	if c.CRDChartOptions.UseTarArchive {
 		if err := filesystem.UnarchiveTgz(pkgFs, filepath.Join(c.WorkingDir, path.ChartExtraFileDir, path.ChartCRDTgzFilename), "", filepath.Join(c.WorkingDir, c.CRDChartOptions.CRDDirectory), false); err != nil {
-			return fmt.Errorf("encountered error while trying to unarchive CRD files from %s: %s", filepath.Join(c.WorkingDir, path.ChartExtraFileDir, path.ChartCRDTgzFilename), err)
+			return fmt.Errorf("encountered error while trying to unarchive CRD files from %s: %s", filepath.Join(c.WorkingDir, "files", path.ChartCRDTgzFilename), err)
 		}
 	}
-	// copy CRD files from packages/<package>/charts-crd/crd-manifest/ back to packages/<package>/charts/crds/
+	// copy CRD files from packages/<package>/<workingDir>/<crdDirectory>/ back to packages/<package>/crds/
 	if err := helm.CopyCRDsFromChart(pkgFs, c.WorkingDir, c.CRDChartOptions.CRDDirectory, mainChartWorkingDir, path.ChartCRDDir); err != nil {
 		return fmt.Errorf("encountered error while trying to copy CRDs from %s to %s: %s", c.WorkingDir, mainChartWorkingDir, err)
 	}

--- a/pkg/charts/parse.go
+++ b/pkg/charts/parse.go
@@ -196,7 +196,7 @@ func GetAdditionalChartFromOptions(opt options.AdditionalChartOptions) (Addition
 		if len(templateDirectory) == 0 {
 			return a, fmt.Errorf("CRD options must provide a template directory")
 		}
-		if crdDirectory == "" {
+		if crdDirectory == "" && useTarArchive {
 			crdDirectory = path.ChartCRDDir
 		}
 		a.CRDChartOptions = &options.CRDChartOptions{

--- a/pkg/charts/parse.go
+++ b/pkg/charts/parse.go
@@ -185,18 +185,25 @@ func GetAdditionalChartFromOptions(opt options.AdditionalChartOptions) (Addition
 	}
 	if opt.CRDChartOptions != nil {
 		crdDirectory := opt.CRDChartOptions.CRDDirectory
-		if len(crdDirectory) == 0 {
-			return a, fmt.Errorf("CRD options must provide a directory to place CRDs within")
+		useTarArchive := opt.CRDChartOptions.UseTarArchive
+		if crdDirectory == "" && !useTarArchive {
+			return a, fmt.Errorf("CRD options must provide a directory to place CRDs within or use tar archive")
+		}
+		if crdDirectory != "" && useTarArchive {
+			return a, fmt.Errorf("CRD options cannot provide both a directory to place CRDs within and use tar archive")
 		}
 		templateDirectory := opt.CRDChartOptions.TemplateDirectory
 		if len(templateDirectory) == 0 {
 			return a, fmt.Errorf("CRD options must provide a template directory")
 		}
+		if crdDirectory == "" {
+			crdDirectory = path.ChartCRDDir
+		}
 		a.CRDChartOptions = &options.CRDChartOptions{
 			TemplateDirectory:           templateDirectory,
 			CRDDirectory:                crdDirectory,
+			UseTarArchive:               useTarArchive,
 			AddCRDValidationToMainChart: opt.CRDChartOptions.AddCRDValidationToMainChart,
-			UseTarArchive:               opt.CRDChartOptions.UseTarArchive,
 		}
 	}
 	return a, nil

--- a/pkg/helm/crds.go
+++ b/pkg/helm/crds.go
@@ -22,6 +22,14 @@ func CopyCRDsFromChart(fs billy.Filesystem, srcHelmChartPath, srcCRDsDir, dstHel
 	}
 	srcCRDsDirpath := filepath.Join(srcHelmChartPath, srcCRDsDir)
 	dstCRDsDirpath := filepath.Join(dstHelmChartPath, destCRDsDir)
+
+	exists, err := filesystem.PathExists(fs, srcCRDsDirpath)
+	if err != nil {
+		return fmt.Errorf("error checking if CRDs directory exists: %s", err)
+	} else if !exists {
+		return os.ErrNotExist
+	}
+
 	logrus.Infof("Copying CRDs from %s to %s", srcCRDsDirpath, dstCRDsDirpath)
 	return filesystem.CopyDir(fs, srcCRDsDirpath, dstCRDsDirpath)
 }

--- a/pkg/options/additionalchart.go
+++ b/pkg/options/additionalchart.go
@@ -18,10 +18,10 @@ type AdditionalChartOptions struct {
 type CRDChartOptions struct {
 	// The directory within packages/<package-name>/templates/ that will contain the template for your CRD chart
 	TemplateDirectory string `yaml:"templateDirectory"`
-	// The directory within your templateDirectory in which CRD files should be placed
+	// The directory within your templateDirectory in which CRD files should be placed. Mutually exclusive with UseTarArchive
 	CRDDirectory string `yaml:"crdDirectory" default:"templates"`
+	// UseTarArchive indicates whether to bundle and compress CRD files into a tgz file. Mutually exclusive with CRDDirectory
+	UseTarArchive bool `yaml:"useTarArchive"`
 	// Whether to add a validation file to your main chart to check that CRDs exist
 	AddCRDValidationToMainChart bool `yaml:"addCRDValidationToMainChart"`
-	// UseTarArchive indicates whether to bundle and compress CRD files into a tgz file
-	UseTarArchive bool `yaml:"useTarArchive"`
 }

--- a/pkg/options/additionalchart.go
+++ b/pkg/options/additionalchart.go
@@ -18,7 +18,7 @@ type AdditionalChartOptions struct {
 type CRDChartOptions struct {
 	// The directory within packages/<package-name>/templates/ that will contain the template for your CRD chart
 	TemplateDirectory string `yaml:"templateDirectory"`
-	// The directory within your templateDirectory in which CRD files should be placed. Mutually exclusive with UseTarArchive
+	// The directory in which to place your crds withint the chart generated from TemplateDirectory. Mutually exclusive with UseTarArchive
 	CRDDirectory string `yaml:"crdDirectory" default:"templates"`
 	// UseTarArchive indicates whether to bundle and compress CRD files into a tgz file. Mutually exclusive with CRDDirectory
 	UseTarArchive bool `yaml:"useTarArchive"`

--- a/pkg/options/additionalchart.go
+++ b/pkg/options/additionalchart.go
@@ -18,7 +18,7 @@ type AdditionalChartOptions struct {
 type CRDChartOptions struct {
 	// The directory within packages/<package-name>/templates/ that will contain the template for your CRD chart
 	TemplateDirectory string `yaml:"templateDirectory"`
-	// The directory in which to place your crds withint the chart generated from TemplateDirectory. Mutually exclusive with UseTarArchive
+	// The directory in which to place your crds within the chart generated from TemplateDirectory. Mutually exclusive with UseTarArchive
 	CRDDirectory string `yaml:"crdDirectory" default:"templates"`
 	// UseTarArchive indicates whether to bundle and compress CRD files into a tgz file. Mutually exclusive with CRDDirectory
 	UseTarArchive bool `yaml:"useTarArchive"`


### PR DESCRIPTION
# Issue

When we enable `UseTarArchive` when generating crd charts from a template, we copy the crds into the crd chart (ex `charts-crd/crd-manifest`) and then create the tar archive. For most situations this is fine; however, any chart generated is going to be much larger than necessary due to having the raw crds included alongside the compressed archive of crds.

For charts with large crds this could result in the chart exceeding the maximum size for a helm chart even when the size of the functional chart files is well below that threshold.

Unfortunately, we cannot simply delete the `CRDDirectory` nor the files it contains due to issues handling the `validate-install-crd.yaml` resource:

```
encountered error while applying main changes from charts-crd to main chart: encountered error while trying to add CRD validation to charts based on CRDs in charts-crd: unable to pull any GroupVersionKinds for CRDs from charts-crd/crd-manifest to construct templates/validate-install-crd.yaml
```

# Solution

If we make the `crdDirectory` and `useTarArchive` crd options mutually exclusive and handle each option separately, we can avoid including bloat into the generated crd charts. This approach also makes it more obvious from the `package.yaml` what we expect to be included in the crd chart.

### Note

This approach does make it more annoying to generate patches for the crd chart since devs cannot just edit the raw crds directly. Now they will have to untar the crd archive, edit the crds, and then recreated the archive with the modified crds.