### PR TITLE
Make lifecycle assets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ go 1.18
 replace k8s.io/client-go => k8s.io/client-go v0.24.3
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,7 @@ github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YH
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=

--- a/main.go
+++ b/main.go
@@ -557,15 +557,16 @@ func checkRCTagsAndVersions(c *cli.Context) {
 }
 
 func lifecycleAssetsClean(c *cli.Context) {
-	// Initialize dependnecies and check necessary files
+	// Initialize dependencies with branch-version, current chart and debug mode
 	repoRoot := getRepoRoot()
-
 	lifeCycleDep, err := lifecycle.InitDependencies(repoRoot, c.String("branch-version"), CurrentChart, DebugMode)
 	if err != nil {
 		logrus.Fatalf("encountered error while initializing dependencies for lifecycle-assets-clean: %s", err)
 	}
-	_ = lifeCycleDep // temporary placeholder, will be removed on a next commit
-	// Initialize dependencies with branch-version, current chart and debug mode
 
 	// Apply versioning rules
+	err = lifeCycleDep.ApplyRules(CurrentChart, DebugMode)
+	if err != nil {
+		logrus.Fatalf("Failed to apply versioning rules for lifecycle-assets-clean: %s", err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
 	"github.com/rancher/charts-build-scripts/pkg/helm"
 	"github.com/rancher/charts-build-scripts/pkg/images"
+	"github.com/rancher/charts-build-scripts/pkg/lifecycle"
 	"github.com/rancher/charts-build-scripts/pkg/options"
 	"github.com/rancher/charts-build-scripts/pkg/path"
 	"github.com/rancher/charts-build-scripts/pkg/puller"
@@ -557,7 +558,13 @@ func checkRCTagsAndVersions(c *cli.Context) {
 
 func lifecycleAssetsClean(c *cli.Context) {
 	// Initialize dependnecies and check necessary files
+	repoRoot := getRepoRoot()
 
+	lifeCycleDep, err := lifecycle.InitDependencies(repoRoot, c.String("branch-version"), CurrentChart, DebugMode)
+	if err != nil {
+		logrus.Fatalf("encountered error while initializing dependencies for lifecycle-assets-clean: %s", err)
+	}
+	_ = lifeCycleDep // temporary placeholder, will be removed on a next commit
 	// Initialize dependencies with branch-version, current chart and debug mode
 
 	// Apply versioning rules

--- a/main.go
+++ b/main.go
@@ -38,6 +38,8 @@ const (
 	DefaultPorcelainEnvironmentVariable = "PORCELAIN"
 	// DefaultCacheEnvironmentVariable is the default environment variable that indicates that a cache should be used on pulls to remotes
 	DefaultCacheEnvironmentVariable = "USE_CACHE"
+	// DefaultDebugEnvironeventVariable is the default environment variable that indicates that debug mode should be enabled
+	DefaultDebugEnvironeventVariable = "DEBUG"
 )
 
 var (
@@ -64,6 +66,8 @@ var (
 	RemoteMode bool
 	// CacheMode indicates that caching should be used on all remotely pulled resources
 	CacheMode = false
+	// DebugMode indicates that debug mode should be enabled
+	DebugMode = false
 )
 
 func main() {
@@ -115,6 +119,16 @@ func main() {
 		Required:    false,
 		Destination: &CacheMode,
 		EnvVar:      DefaultCacheEnvironmentVariable,
+	}
+	branchVersionFlag := cli.StringFlag{
+		Name:  "branch-version",
+		Usage: "Available inputs: (2.5; 2.6; 2.7; 2.8; 2.9). The branch version to compare against. This is used to determine which assets to remove from the repository. ",
+	}
+	debugFlag := cli.BoolFlag{
+		Name:        "debugFlag",
+		Usage:       "Enable debug mode",
+		Destination: &DebugMode,
+		EnvVar:      DefaultDebugEnvironeventVariable,
 	}
 	app.Commands = []cli.Command{
 		{
@@ -235,6 +249,12 @@ func main() {
 			Usage:  "Download the chart icon locally and use it",
 			Action: downloadIcon,
 			Flags:  []cli.Flag{packageFlag, configFlag, cacheFlag},
+		},
+		{
+			Name:   "lifecycle-assets",
+			Usage:  "Clean up assets that don't belong on this branch",
+			Action: lifecycleAssetsClean,
+			Flags:  []cli.Flag{branchVersionFlag, chartFlag, debugFlag},
 		},
 	}
 
@@ -533,4 +553,12 @@ func checkRCTagsAndVersions(c *cli.Context) {
 	}
 
 	logrus.Info("RC check has succeeded")
+}
+
+func lifecycleAssetsClean(c *cli.Context) {
+	// Initialize dependnecies and check necessary files
+
+	// Initialize dependencies with branch-version, current chart and debug mode
+
+	// Apply versioning rules
 }

--- a/main.go
+++ b/main.go
@@ -39,8 +39,8 @@ const (
 	DefaultPorcelainEnvironmentVariable = "PORCELAIN"
 	// DefaultCacheEnvironmentVariable is the default environment variable that indicates that a cache should be used on pulls to remotes
 	DefaultCacheEnvironmentVariable = "USE_CACHE"
-	// DefaultDebugEnvironeventVariable is the default environment variable that indicates that debug mode should be enabled
-	DefaultDebugEnvironeventVariable = "DEBUG"
+	// DefaultDebugEnvironmentVariable is the default environment variable that indicates that debug mode should be enabled
+	DefaultDebugEnvironmentVariable = "DEBUG"
 )
 
 var (
@@ -129,7 +129,7 @@ func main() {
 		Name:        "debugFlag",
 		Usage:       "Enable debug mode",
 		Destination: &DebugMode,
-		EnvVar:      DefaultDebugEnvironeventVariable,
+		EnvVar:      DefaultDebugEnvironmentVariable,
 	}
 	app.Commands = []cli.Command{
 		{

--- a/pkg/lifecycle/git.go
+++ b/pkg/lifecycle/git.go
@@ -1,0 +1,25 @@
+package lifecycle
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func checkIfGitIsClean(debug bool) (bool, error) {
+	cmd := exec.Command("git", "status", "--porcelain")
+	if debug {
+		cmd := exec.Command("git", "status")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Run()
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("error while checking if git is clean: %s", err)
+	}
+	if len(output) > 0 {
+		return false, nil
+	}
+	return true, nil
+}

--- a/pkg/lifecycle/git.go
+++ b/pkg/lifecycle/git.go
@@ -23,3 +23,20 @@ func checkIfGitIsClean(debug bool) (bool, error) {
 	}
 	return true, nil
 }
+
+func gitAddAndCommit(message string) error {
+
+	// Stage all changes, including deletions
+	cmd := exec.Command("git", "add", "-A")
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	// Commit the staged changes
+	cmd = exec.Command("git", "commit", "-m", message)
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -1,0 +1,96 @@
+package lifecycle
+
+import (
+	"fmt"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/rancher/charts-build-scripts/pkg/filesystem"
+	"github.com/rancher/charts-build-scripts/pkg/path"
+	"github.com/sirupsen/logrus"
+)
+
+// Asset represents an asset with its version and path in the repository
+type Asset struct {
+	version string
+	path    string
+}
+
+// Dependencies struct holds the necessary filesystem,
+// assets versions map, version rules and methods
+// to apply the lifecycle rules in the target branch
+type Dependencies struct {
+	rootFs            billy.Filesystem
+	assetsVersionsMap map[string][]Asset
+	vr                *VersionRules
+	// These wrappers are used to mock the filesystem and git status in the tests
+	checkIfGitIsCleanWrapper CheckIfGitIsCleanFunc
+}
+
+// CheckIfGitIsCleanFunc is a function type that will be used to check if the git tree is clean
+type CheckIfGitIsCleanFunc func(debug bool) (bool, error)
+
+func cycleLog(debugMode bool, msg string, data interface{}) {
+	if debugMode {
+		if data != nil {
+			logrus.Debugf("%s: %#+v \n", msg, data)
+		} else {
+			logrus.Debug(msg)
+		}
+	}
+}
+
+// InitDependencies will check the filesystem, branch version,
+// git status, initialize the Dependencies struct and populate it.
+// If anything fails the operation will be aborted.
+func InitDependencies(repoRoot, branchVersion string, currentChart string, debug bool) (*Dependencies, error) {
+	logrus.SetFormatter(&logrus.TextFormatter{
+		DisableQuote: true,
+	})
+	var err error
+	// Create a new Dependencies struct
+	dep := &Dependencies{
+		checkIfGitIsCleanWrapper: checkIfGitIsClean, // Assign the checkIfGitIsClean function to the wrapper
+
+	}
+
+	cycleLog(debug, "Getting branch version rules for: ", branchVersion)
+	// Initialize and check version rules for the current branch
+	dep.vr, err = GetVersionRules(branchVersion, debug)
+	if err != nil {
+		return nil, fmt.Errorf("encountered error while getting current branch version: %s", err)
+	}
+
+	// Get the filesystem and index.yaml path for the repository
+	dep.rootFs = filesystem.GetFilesystem(repoRoot)
+
+	// Check if the assets folder and Helm index file exists in the repository
+	exists, err := filesystem.PathExists(dep.rootFs, path.RepositoryAssetsDir)
+	if err != nil || !exists {
+		return nil, fmt.Errorf("encountered error while checking if assets folder already exists in repository: %s", err)
+	}
+	exists, err = filesystem.PathExists(dep.rootFs, path.RepositoryHelmIndexFile)
+	if err != nil || !exists {
+		return nil, fmt.Errorf("encountered error while checking if Helm index file already exists in repository: %s", err)
+	}
+
+	// Get the absolute path of the Helm index file and assets versions map to apply rules
+	helmIndexPath := filesystem.GetAbsPath(dep.rootFs, path.RepositoryHelmIndexFile)
+	dep.assetsVersionsMap, err = getAssetsMapFromIndex(helmIndexPath, currentChart, debug)
+	if len(dep.assetsVersionsMap) == 0 {
+		return nil, fmt.Errorf("no assets found in the repository")
+	}
+	if err != nil {
+		return nil, err // Abort and return error if the assets map is empty
+	}
+
+	// Git tree must be clean before proceeding with removing charts
+	clean, err := dep.checkIfGitIsCleanWrapper(debug)
+	if !clean {
+		return nil, fmt.Errorf("git is not clean, it must be clean before proceeding with removing charts")
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return dep, nil
+}

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -113,7 +113,7 @@ func Test_removeVersionsAssets(t *testing.T) {
 			t.Errorf("Expected 2 removed assets, got %d", len(removedAssetsVersions))
 
 		case len(removedAssetsVersions["chart1"]) != 3:
-			t.Errorf("Expected 2 removed assets for chart1, got %d", len(removedAssetsVersions["chart1"]))
+			t.Errorf("Expected 3 removed assets for chart1, got %d", len(removedAssetsVersions["chart1"]))
 
 		case len(removedAssetsVersions["chart2"]) != 2:
 			t.Errorf("Expected 2 removed assets for chart2, got %d", len(removedAssetsVersions["chart2"]))

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func Test_removeVersionsAssets(t *testing.T) {
+func Test_removeAssetsVersions(t *testing.T) {
 
 	t.Run("Remove Versions Assets fail at makeRemoveWrapper", func(t *testing.T) {
 		// Init and mock dependencies
@@ -22,11 +22,11 @@ func Test_removeVersionsAssets(t *testing.T) {
 		}
 
 		// Execute
-		_, err := dep.removeVersionsAssets(false)
+		_, err := dep.removeAssetsVersions(false)
 
 		// Assert
 		if err == nil {
-			t.Errorf("removeVersionsAssets returned an error: %v", err)
+			t.Errorf("removeAssetsVersions should have returned an error: %v", err)
 		}
 	})
 
@@ -45,11 +45,11 @@ func Test_removeVersionsAssets(t *testing.T) {
 		}
 
 		// Execute
-		_, err := dep.removeVersionsAssets(false)
+		_, err := dep.removeAssetsVersions(false)
 
 		// Assert
 		if err == nil {
-			t.Errorf("removeVersionsAssets returned an error: %v", err)
+			t.Errorf("removeAssetsVersions should have returned an error: %v", err)
 		}
 	})
 
@@ -68,11 +68,11 @@ func Test_removeVersionsAssets(t *testing.T) {
 		}
 
 		// Execute
-		_, err := dep.removeVersionsAssets(false)
+		_, err := dep.removeAssetsVersions(false)
 
 		// Assert
 		if err == nil {
-			t.Errorf("removeVersionsAssets returned an error: %v", err)
+			t.Errorf("removeAssetsVersions should have returned an error: %v", err)
 		}
 	})
 
@@ -102,12 +102,12 @@ func Test_removeVersionsAssets(t *testing.T) {
 		}
 
 		// Execute
-		removedAssetsVersions, err := dep.removeVersionsAssets(false)
+		removedAssetsVersions, err := dep.removeAssetsVersions(false)
 
 		// Assert
 		switch {
 		case err != nil:
-			t.Errorf("removeVersionsAssets returned an error: %v", err)
+			t.Errorf("removeAssetsVersions returned an error: %v", err)
 
 		case len(removedAssetsVersions) != 2:
 			t.Errorf("Expected 2 removed assets, got %d", len(removedAssetsVersions))
@@ -152,12 +152,12 @@ func Test_removeVersionsAssets(t *testing.T) {
 		}
 
 		// Execute
-		removedAssetsVersions, err := dep.removeVersionsAssets(false)
+		removedAssetsVersions, err := dep.removeAssetsVersions(false)
 
 		// Assert
 		switch {
 		case err != nil:
-			t.Errorf("removeVersionsAssets returned an error: %v", err)
+			t.Errorf("removeAssetsVersions returned an error: %v", err)
 
 		case len(removedAssetsVersions) != 1:
 			t.Errorf("Expected 1 removed assets in slice, got %d", len(removedAssetsVersions))
@@ -182,12 +182,12 @@ func Test_removeVersionsAssets(t *testing.T) {
 		}
 
 		// Execute
-		removedAssetsVersions, err := dep.removeVersionsAssets(false)
+		removedAssetsVersions, err := dep.removeAssetsVersions(false)
 
 		// Assert
 		switch {
 		case err != nil:
-			t.Errorf("removeVersionsAssets returned an error: %v", err)
+			t.Errorf("removeAssetsVersions returned an error: %v", err)
 
 		case len(removedAssetsVersions) != 0:
 			t.Errorf("Expected 0 removed assets, got %d", len(removedAssetsVersions))

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -1,0 +1,197 @@
+package lifecycle
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_removeVersionsAssets(t *testing.T) {
+
+	t.Run("Remove Versions Assets fail at makeRemoveWrapper", func(t *testing.T) {
+		// Init and mock dependencies
+		vr, _ := GetVersionRules("2.9", false)
+		dep := &Dependencies{
+			// initialize other fields as necessary
+			makeRemoveWrapper: func(chart, version string, debug bool) error {
+				return fmt.Errorf("Some error at makeRemoveWrapper")
+			},
+			checkIfGitIsCleanWrapper: func(debug bool) (bool, error) { return false, nil },
+			gitAddAndCommitWrapper:   func(message string) error { return nil },
+			assetsVersionsMap:        map[string][]Asset{"chart1": {{version: "999.0.0"}}},
+			vr:                       vr,
+		}
+
+		// Execute
+		_, err := dep.removeVersionsAssets(false)
+
+		// Assert
+		if err == nil {
+			t.Errorf("removeVersionsAssets returned an error: %v", err)
+		}
+	})
+
+	t.Run("Remove Versions Assets fail at checkIfGitIsCleanWrapper", func(t *testing.T) {
+		// Init and mock dependencies
+		vr, _ := GetVersionRules("2.9", false)
+		dep := &Dependencies{
+			// initialize other fields as necessary
+			makeRemoveWrapper: func(chart, version string, debug bool) error { return nil },
+			checkIfGitIsCleanWrapper: func(debug bool) (bool, error) {
+				return false, fmt.Errorf("Some error at checkIfGitIsCleanWrapper")
+			},
+			gitAddAndCommitWrapper: func(message string) error { return nil },
+			assetsVersionsMap:      map[string][]Asset{"chart1": {{version: "999.0.0"}}},
+			vr:                     vr,
+		}
+
+		// Execute
+		_, err := dep.removeVersionsAssets(false)
+
+		// Assert
+		if err == nil {
+			t.Errorf("removeVersionsAssets returned an error: %v", err)
+		}
+	})
+
+	t.Run("Remove Versions Assets fail at gitAddAndCommitWrapper", func(t *testing.T) {
+		// Init and mock dependencies
+		vr, _ := GetVersionRules("2.9", false)
+		dep := &Dependencies{
+			// initialize other fields as necessary
+			makeRemoveWrapper:        func(chart, version string, debug bool) error { return nil },
+			checkIfGitIsCleanWrapper: func(debug bool) (bool, error) { return false, nil },
+			gitAddAndCommitWrapper: func(message string) error {
+				return fmt.Errorf("Some error at gitAddAndCommitWrapper")
+			},
+			assetsVersionsMap: map[string][]Asset{"chart1": {{version: "999.0.0"}}},
+			vr:                vr,
+		}
+
+		// Execute
+		_, err := dep.removeVersionsAssets(false)
+
+		// Assert
+		if err == nil {
+			t.Errorf("removeVersionsAssets returned an error: %v", err)
+		}
+	})
+
+	t.Run("Remove Versions Assets successfully", func(t *testing.T) {
+		// Init and mock dependencies
+		vr, _ := GetVersionRules("2.9", false)
+		dep := &Dependencies{
+			makeRemoveWrapper:        func(chart, version string, debug bool) error { return nil },
+			checkIfGitIsCleanWrapper: func(debug bool) (bool, error) { return false, nil },
+			gitAddAndCommitWrapper:   func(message string) error { return nil },
+			assetsVersionsMap: map[string][]Asset{
+				"chart1": {
+					{version: "105.0.0"},
+					{version: "104.1.0"},
+					{version: "103.0.1"},
+					{version: "102.9.150"},
+					{version: "101.0.0"},
+					{version: "100.0.0"},
+					{version: "99.9.9"},
+				},
+				"chart2": {
+					{version: "110.0.0"},
+					{version: "0.1.0"},
+				},
+			},
+			vr: vr,
+		}
+
+		// Execute
+		removedAssetsVersions, err := dep.removeVersionsAssets(false)
+
+		// Assert
+		switch {
+		case err != nil:
+			t.Errorf("removeVersionsAssets returned an error: %v", err)
+
+		case len(removedAssetsVersions) != 2:
+			t.Errorf("Expected 2 removed assets, got %d", len(removedAssetsVersions))
+
+		case len(removedAssetsVersions["chart1"]) != 3:
+			t.Errorf("Expected 2 removed assets for chart1, got %d", len(removedAssetsVersions["chart1"]))
+
+		case len(removedAssetsVersions["chart2"]) != 2:
+			t.Errorf("Expected 2 removed assets for chart2, got %d", len(removedAssetsVersions["chart2"]))
+		}
+
+		for _, asset := range removedAssetsVersions["chart1"] {
+			if asset.version == "105.0.0" || asset.version == "100.0.0" || asset.version == "99.9.9" {
+				continue
+			}
+			t.Errorf("Unexpected removed asset version on chart1: %s", asset.version)
+		}
+
+		for _, asset := range removedAssetsVersions["chart2"] {
+			if asset.version == "110.0.0" || asset.version == "0.1.0" {
+				continue
+			}
+			t.Errorf("Unexpected removed asset version on chart2: %s", asset.version)
+		}
+	})
+
+	t.Run("Remove Versions Assets successfully (nothing to remove)", func(t *testing.T) {
+		// Init and mock dependencies
+		vr, _ := GetVersionRules("2.9", false)
+		dep := &Dependencies{
+			makeRemoveWrapper:        func(chart, version string, debug bool) error { return nil },
+			checkIfGitIsCleanWrapper: func(debug bool) (bool, error) { return false, nil },
+			gitAddAndCommitWrapper:   func(message string) error { return nil },
+			assetsVersionsMap: map[string][]Asset{
+				"chart1": {
+					{version: "103.0.1"},
+					{version: "102.9.150"},
+					{version: "101.0.0"},
+				},
+			},
+			vr: vr,
+		}
+
+		// Execute
+		removedAssetsVersions, err := dep.removeVersionsAssets(false)
+
+		// Assert
+		switch {
+		case err != nil:
+			t.Errorf("removeVersionsAssets returned an error: %v", err)
+
+		case len(removedAssetsVersions) != 1:
+			t.Errorf("Expected 1 removed assets in slice, got %d", len(removedAssetsVersions))
+
+		case len(removedAssetsVersions["chart1"]) != 0:
+			t.Errorf("Expected 0 removed assets for chart1, got %d", len(removedAssetsVersions["chart1"]))
+
+		}
+	})
+
+	t.Run("Remove Versions Assets successfully (empty assetVersionsMap to remove)", func(t *testing.T) {
+		// Init and mock dependencies
+		vr, _ := GetVersionRules("2.9", false)
+		dep := &Dependencies{
+			makeRemoveWrapper:        func(chart, version string, debug bool) error { return nil },
+			checkIfGitIsCleanWrapper: func(debug bool) (bool, error) { return true, nil },
+			gitAddAndCommitWrapper:   func(message string) error { return nil },
+			assetsVersionsMap: map[string][]Asset{
+				"chart1": {},
+			},
+			vr: vr,
+		}
+
+		// Execute
+		removedAssetsVersions, err := dep.removeVersionsAssets(false)
+
+		// Assert
+		switch {
+		case err != nil:
+			t.Errorf("removeVersionsAssets returned an error: %v", err)
+
+		case len(removedAssetsVersions) != 0:
+			t.Errorf("Expected 0 removed assets, got %d", len(removedAssetsVersions))
+
+		}
+	})
+}

--- a/pkg/lifecycle/mocks/test.yaml
+++ b/pkg/lifecycle/mocks/test.yaml
@@ -1,0 +1,104 @@
+apiVersion: v1
+entries:
+  chart-one:
+  - annotations:
+      catalog.cattle.io/certified: rancher
+      catalog.cattle.io/display-name: Istio
+      catalog.cattle.io/kube-version: '>= 1.23.0-0 < 1.28.0-0'
+      catalog.cattle.io/namespace: istio-system
+      catalog.cattle.io/os: linux
+      catalog.cattle.io/permits-os: linux,windows
+      catalog.cattle.io/rancher-version: '>= 2.8.0-0 < 2.9.0-0'
+      catalog.cattle.io/release-name: chart-one
+      catalog.cattle.io/requests-cpu: 710m
+      catalog.cattle.io/requests-memory: 2314Mi
+      catalog.cattle.io/type: cluster-tool
+      catalog.cattle.io/ui-component: istio
+      catalog.cattle.io/upstream-version: 1.18.2
+    apiVersion: v1
+    appVersion: 1.18.2
+    created: "2023-11-20T16:09:13.511925-03:00"
+    dependencies:
+    - condition: kiali.enabled
+      name: kiali
+      repository: file://./charts/kiali
+    - condition: tracing.enabled
+      name: tracing
+      repository: file://./charts/tracing
+    description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/
+      for details.
+    digest: 7f0bb03b7b2f2fe702f78d0941499d593256e8a01e7752f0850e6eaa545e513d
+    icon: https://charts.rancher.io/assets/logos/istio.svg
+    keywords:
+    - networking
+    - infrastructure
+    name: chart-one
+    urls:
+    - assets/chart-one/chart-one-103.0.0+up1.18.2.tgz
+    version: 103.0.0+up1.18.2
+  - annotations:
+      catalog.cattle.io/certified: rancher
+      catalog.cattle.io/display-name: Istio
+      catalog.cattle.io/kube-version: '>= 1.23.0-0 < 1.28.0-0'
+      catalog.cattle.io/namespace: istio-system
+      catalog.cattle.io/os: linux
+      catalog.cattle.io/permits-os: linux,windows
+      catalog.cattle.io/rancher-version: '>= 2.7.0-0 < 2.8.0-0'
+      catalog.cattle.io/release-name: chart-one
+      catalog.cattle.io/requests-cpu: 710m
+      catalog.cattle.io/requests-memory: 2314Mi
+      catalog.cattle.io/type: cluster-tool
+      catalog.cattle.io/ui-component: istio
+      catalog.cattle.io/upstream-version: 1.18.2
+    apiVersion: v1
+    appVersion: 1.18.2
+    created: "2023-11-02T16:09:16.1541-03:00"
+    dependencies:
+    - condition: kiali.enabled
+      name: kiali
+      repository: file://./charts/kiali
+    - condition: tracing.enabled
+      name: tracing
+      repository: file://./charts/tracing
+    description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/
+      for details.
+    digest: 110a32f83814acab1c71dd1b0325f0fb6256879851f0828da17ba40b796a36b5
+    icon: https://charts.rancher.io/assets/logos/istio.svg
+    keywords:
+    - networking
+    - infrastructure
+    name: chart-one
+    urls:
+    - assets/chart-one/chart-one-102.3.1+up1.18.2.tgz
+    version: 102.3.1+up1.18.2
+  chart-two:
+  - annotations:
+      catalog.cattle.io/auto-install: chart-two-crd=match
+      catalog.cattle.io/certified: rancher
+      catalog.cattle.io/display-name: Rancher Backups
+      catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.25.0-0'
+      catalog.cattle.io/namespace: cattle-resources-system
+      catalog.cattle.io/os: linux
+      catalog.cattle.io/permits-os: linux,windows
+      catalog.cattle.io/provides-gvr: resources.cattle.io.resourceset/v1
+      catalog.cattle.io/rancher-version: '>= 2.7.0-0 < 2.8.0-0'
+      catalog.cattle.io/release-name: chart-two
+      catalog.cattle.io/scope: management
+      catalog.cattle.io/type: cluster-tool
+      catalog.cattle.io/ui-component: chart-two
+      catalog.cattle.io/upstream-version: 2.1.1
+    apiVersion: v2
+    appVersion: 3.0.0
+    created: "2022-11-09T11:52:02.066858-05:00"
+    description: Provides ability to back up and restore the Rancher application running
+      on any Kubernetes cluster
+    digest: a3deb4338e3fa3d9e21c34c046d3d236879661bba5c1b5d101a534848350c779
+    icon: https://charts.rancher.io/assets/logos/backup-restore.svg
+    keywords:
+    - applications
+    - infrastructure
+    kubeVersion: '>= 1.16.0-0'
+    name: chart-two
+    urls:
+    - assets/chart-two/chart-two-3.0.0.tgz
+    version: 3.0.0

--- a/pkg/lifecycle/parser.go
+++ b/pkg/lifecycle/parser.go
@@ -1,0 +1,50 @@
+package lifecycle
+
+import (
+	"fmt"
+	"os"
+
+	helmRepo "helm.sh/helm/v3/pkg/repo"
+)
+
+// getAssetsMapFromIndex returns a map of assets with their version and
+// an empty path that will be populated later by populateAssetsVersionsPath()
+func getAssetsMapFromIndex(absRepositoryHelmIndexFile, currentChart string, debug bool) (map[string][]Asset, error) {
+	fmt.Println(os.Getwd())
+	helmIndexFile, err := helmRepo.LoadIndexFile(absRepositoryHelmIndexFile)
+	if err != nil {
+		return nil, fmt.Errorf("encountered error while trying to load existing index file: %s", err)
+	}
+
+	var assetsMap = make(map[string][]Asset)
+	var annotatedVersions []Asset
+
+	switch {
+	case currentChart == "":
+		cycleLog(debug, "Current chart is empty, getting all charts", nil)
+		for _, entry := range helmIndexFile.Entries {
+			for _, chartVersion := range entry {
+				annotatedVersions = append(annotatedVersions, Asset{
+					version: chartVersion.Version,
+				})
+			}
+			assetsMap[entry[0].Name] = annotatedVersions
+			annotatedVersions = nil // Reset the slice for the next iteration
+		}
+
+	case currentChart != "":
+		cycleLog(debug, "Target chart is", currentChart)
+		if _, ok := helmIndexFile.Entries[currentChart]; !ok {
+			return nil, fmt.Errorf("chart %s not found in the index file", currentChart)
+		}
+		for _, chartVersion := range helmIndexFile.Entries[currentChart] {
+			annotatedVersions = append(annotatedVersions, Asset{
+				version: chartVersion.Version,
+				// path:    chartVersion.URLs[0], we can't trust this field
+			})
+		}
+		assetsMap[currentChart] = annotatedVersions
+	}
+
+	return assetsMap, nil
+}

--- a/pkg/lifecycle/parser.go
+++ b/pkg/lifecycle/parser.go
@@ -26,13 +26,13 @@ func getAssetsMapFromIndex(absRepositoryHelmIndexFile, currentChart string, debu
 	switch {
 	case currentChart == "":
 		cycleLog(debug, "Current chart is empty, getting all charts", nil)
-		for _, entry := range helmIndexFile.Entries {
+		for chartName, entry := range helmIndexFile.Entries {
 			for _, chartVersion := range entry {
 				annotatedVersions = append(annotatedVersions, Asset{
 					version: chartVersion.Version,
 				})
 			}
-			assetsMap[entry[0].Name] = annotatedVersions
+			assetsMap[chartName] = annotatedVersions
 			annotatedVersions = nil // Reset the slice for the next iteration
 		}
 
@@ -44,7 +44,6 @@ func getAssetsMapFromIndex(absRepositoryHelmIndexFile, currentChart string, debu
 		for _, chartVersion := range helmIndexFile.Entries[currentChart] {
 			annotatedVersions = append(annotatedVersions, Asset{
 				version: chartVersion.Version,
-				// path:    chartVersion.URLs[0], we can't trust this field
 			})
 		}
 		assetsMap[currentChart] = annotatedVersions

--- a/pkg/lifecycle/parser.go
+++ b/pkg/lifecycle/parser.go
@@ -84,14 +84,14 @@ func (ld *Dependencies) populateAssetsVersionsPath(debug bool) error {
 			return fmt.Errorf("encountered error while walking through the assets directory: %w", err)
 		}
 
-		// Now we have the path of the assets, at filePaths
+		// Now we have the path of the assets, at filePaths slice
 		for _, asset := range assets {
 			for _, filePath := range filePaths {
 				// Ranging through assets and filePaths to get the version of the asset
 				version := strings.TrimPrefix(filePath, dirPath+"/"+chart+"-")
 				version = strings.TrimSuffix(version, ".tgz")
 				// Compare the received slice of paths with the current versions in assets
-				// lets append the path to the assetsMap
+				// lets append the path to the assetsVersionsMap
 				if asset.version == version {
 					cycleLog(debug, "adding asset to map", filePath)
 					asset.path = filePath

--- a/pkg/lifecycle/parser_test.go
+++ b/pkg/lifecycle/parser_test.go
@@ -1,0 +1,173 @@
+package lifecycle
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/rancher/charts-build-scripts/pkg/filesystem"
+)
+
+func Test_getAssetsMapFromIndex(t *testing.T) {
+	t.Run("Fail to load Index File", func(t *testing.T) {
+		_, err := getAssetsMapFromIndex("", "", false)
+		if err == nil {
+			t.Errorf("Expected error when failing to load Index file")
+		}
+	})
+
+	t.Run("Load all charts successfully", func(t *testing.T) {
+		assetsVersionsMapTest1, err := getAssetsMapFromIndex("mocks/test.yaml", "", false)
+
+		if err != nil {
+			t.Errorf("Error not expected when failing to load Index file %v", err)
+		}
+		if len(assetsVersionsMapTest1) != 2 {
+			t.Errorf("Expected to load 2 charts")
+		}
+		if len(assetsVersionsMapTest1["chart-one"]) != 2 {
+			t.Errorf("Expected to load 2 versions for chart1, got %v", len(assetsVersionsMapTest1["chart-one"]))
+		}
+		if len(assetsVersionsMapTest1["chart-two"]) != 1 {
+			t.Errorf("Expected to load 1 version for chart2, got %v", len(assetsVersionsMapTest1["chart-one"]))
+		}
+	})
+
+	t.Run("Fail to load target chart (chart-zero)", func(t *testing.T) {
+		_, err := getAssetsMapFromIndex("mocks/test.yaml", "chart-zero", false)
+		if err == nil {
+			t.Errorf("Expected error when failing to load Index file")
+		}
+	})
+
+	t.Run("Load target chart (chart-one) successfully", func(t *testing.T) {
+		assetsVersionsMapTest, err := getAssetsMapFromIndex("mocks/test.yaml", "chart-one", false)
+
+		if err != nil {
+			t.Errorf("Error not expected when failing to load Index file %v", err)
+		}
+		if len(assetsVersionsMapTest) != 1 {
+			t.Errorf("Expected to load 1 chart")
+		}
+		if len(assetsVersionsMapTest["chart-one"]) != 2 {
+			t.Errorf("Expected to load 1 version for chart2, got %v", len(assetsVersionsMapTest["chart-one"]))
+		}
+	})
+
+	t.Run("Load target chart (chart-two) successfully", func(t *testing.T) {
+		assetsVersionsMapTest, err := getAssetsMapFromIndex("mocks/test.yaml", "chart-two", false)
+
+		if err != nil {
+			t.Errorf("Error not expected when failing to load Index file %v", err)
+		}
+		if len(assetsVersionsMapTest) != 1 {
+			t.Errorf("Expected to load 1 chart")
+		}
+		if len(assetsVersionsMapTest["chart-two"]) != 1 {
+			t.Errorf("Expected to load 1 version for chart2, got %v", len(assetsVersionsMapTest["chart-one"]))
+		}
+	})
+}
+
+func Test_populateAssetsVersionsPath(t *testing.T) {
+	t.Run("Populate assets versions map successfully", func(t *testing.T) {
+		// Create a test instance of Dependencies with a pre-populated assetsVersionsMap
+		ld := &Dependencies{
+			// rootFs: fs,
+			assetsVersionsMap: map[string][]Asset{
+				"chart1": {
+					{version: "1.0.0"},
+				},
+				"chart2": {
+					{version: "1.0.0"},
+				},
+			},
+			walkDirWrapper: func(fs billy.Filesystem, dirPath string, doFunc filesystem.RelativePathFunc) error {
+				// Simulate the behavior of filesystem.WalkDir as needed for your test.
+				if dirPath == "assets/chart1" {
+					doFunc(nil, "assets/chart1/chart1-1.0.0.tgz", false)
+				}
+				if dirPath == "assets/chart2" {
+					doFunc(nil, "assets/chart2/chart2-1.0.0.tgz", false)
+				}
+				return nil
+			},
+		}
+
+		// Call the function we're testing
+		err := ld.populateAssetsVersionsPath(false)
+		if err != nil {
+			t.Fatalf("populateAssetsVersionsPath returned an error: %v", err)
+		}
+
+		// Check that the assetsVersionsMap was populated correctly
+		expected := map[string][]Asset{
+			"chart1": {
+				{version: "1.0.0", path: "assets/chart1/chart1-1.0.0.tgz"},
+			},
+			"chart2": {
+				{version: "1.0.0", path: "assets/chart2/chart2-1.0.0.tgz"},
+			},
+		}
+		if !reflect.DeepEqual(ld.assetsVersionsMap, expected) {
+			t.Errorf("assetsVersionsMap was not populated correctly, got: %v, want: %v", ld.assetsVersionsMap, expected)
+		}
+	})
+
+	t.Run("Fail to walk through the assets directory", func(t *testing.T) {
+		// Create a test instance of Dependencies with a pre-populated assetsVersionsMap
+		ld := &Dependencies{
+			// rootFs: fs,
+			assetsVersionsMap: map[string][]Asset{
+				"chart1": {
+					{version: "1.0.0"},
+				},
+			},
+			walkDirWrapper: func(fs billy.Filesystem, dirPath string, doFunc filesystem.RelativePathFunc) error {
+				doFunc(nil, "", false)
+				return fmt.Errorf("Some random error")
+			},
+		}
+
+		// Call the function we're testing
+		err := ld.populateAssetsVersionsPath(false)
+		if err == nil {
+			t.Fatalf("populateAssetsVersionsPath returned an error: %v", err)
+		}
+	})
+}
+
+func Test_sortAssetsVersions(t *testing.T) {
+	// Arrange
+	dep := &Dependencies{
+		assetsVersionsMap: map[string][]Asset{
+			"key1": {
+				{version: "1.0.0"},
+				{version: "0.1.0"},
+				{version: "0.0.1"},
+			},
+			"key2": {
+				{version: "2.0.0"},
+				{version: "1.1.0"},
+				{version: "1.0.1"},
+			},
+		},
+	}
+
+	// Act
+	dep.sortAssetsVersions()
+
+	// Assert
+	if dep.assetsVersionsMap["key1"][0].version != "0.0.1" ||
+		dep.assetsVersionsMap["key1"][1].version != "0.1.0" ||
+		dep.assetsVersionsMap["key1"][2].version != "1.0.0" {
+		t.Errorf("assetsVersionsMap was not sorted correctly for key1")
+	}
+
+	if dep.assetsVersionsMap["key2"][0].version != "1.0.1" ||
+		dep.assetsVersionsMap["key2"][1].version != "1.1.0" ||
+		dep.assetsVersionsMap["key2"][2].version != "2.0.0" {
+		t.Errorf("assetsVersionsMap was not sorted correctly for key2")
+	}
+}

--- a/pkg/lifecycle/parser_test.go
+++ b/pkg/lifecycle/parser_test.go
@@ -133,7 +133,7 @@ func Test_populateAssetsVersionsPath(t *testing.T) {
 		// Call the function we're testing
 		err := ld.populateAssetsVersionsPath(false)
 		if err == nil {
-			t.Fatalf("populateAssetsVersionsPath returned an error: %v", err)
+			t.Fatalf("populateAssetsVersionsPath should have returned an error: %v", err)
 		}
 	})
 }

--- a/pkg/lifecycle/version.rules_test.go
+++ b/pkg/lifecycle/version.rules_test.go
@@ -1,0 +1,103 @@
+package lifecycle
+
+import (
+	"testing"
+)
+
+func TestGetVersionRules(t *testing.T) {
+	t.Run("branchVersion is empty", func(t *testing.T) {
+		_, err := GetVersionRules("", false)
+		if err == nil {
+			t.Errorf("Expected error when branchVersion is empty")
+		}
+	})
+
+	t.Run("branchVersion is not convertible to float32", func(t *testing.T) {
+		_, err := GetVersionRules("not a float", false)
+		if err == nil {
+			t.Errorf("Expected error when branchVersion is not convertible to float32")
+		}
+	})
+
+	t.Run("branchVersion is not defined in the rules", func(t *testing.T) {
+		_, err := GetVersionRules("3.0", false)
+		if err == nil {
+			t.Errorf("Expected error when branchVersion is not defined in the rules")
+		}
+	})
+
+	t.Run("branchVersion is defined in the rules for branch: 2.9", func(t *testing.T) {
+		vr, err := GetVersionRules("2.9", false)
+		if err != nil {
+			t.Errorf("Unexpected error when branchVersion is defined in the rules: %v", err)
+		}
+		switch {
+		case vr.branchVersion != 2.9:
+			t.Errorf("Expected branchVersion to be 2.9, got %v", vr.branchVersion)
+		case vr.minVersion != 101:
+			t.Errorf("Expected minVersion to be 101, got %v", vr.minVersion)
+		case vr.maxVersion != 105:
+			t.Errorf("Expected maxVersion to be 105, got %v", vr.maxVersion)
+		}
+	})
+
+	t.Run("branchVersion is defined in the rules for branch: 2.8", func(t *testing.T) {
+		vr, err := GetVersionRules("2.8", false)
+		if err != nil {
+			t.Errorf("Unexpected error when branchVersion is defined in the rules: %v", err)
+		}
+		switch {
+		case vr.branchVersion != 2.8:
+			t.Errorf("Expected branchVersion to be 2.8, got %v", vr.branchVersion)
+		case vr.minVersion != 100:
+			t.Errorf("Expected minVersion to be 100, got %v", vr.minVersion)
+		case vr.maxVersion != 104:
+			t.Errorf("Expected maxVersion to be 104, got %v", vr.maxVersion)
+		}
+	})
+
+	t.Run("branchVersion is defined in the rules for branch: 2.7", func(t *testing.T) {
+		vr, err := GetVersionRules("2.7", false)
+		if err != nil {
+			t.Errorf("Unexpected error when branchVersion is defined in the rules: %v", err)
+		}
+		switch {
+		case vr.branchVersion != 2.7:
+			t.Errorf("Expected branchVersion to be 2.7, got %v", vr.branchVersion)
+		case vr.minVersion != 0:
+			t.Errorf("Expected minVersion to be 0, got %v", vr.minVersion)
+		case vr.maxVersion != 103:
+			t.Errorf("Expected maxVersion to be 103, got %v", vr.maxVersion)
+		}
+	})
+
+	t.Run("branchVersion is defined in the rules for branch: 2.6", func(t *testing.T) {
+		vr, err := GetVersionRules("2.6", false)
+		if err != nil {
+			t.Errorf("Unexpected error when branchVersion is defined in the rules: %v", err)
+		}
+		switch {
+		case vr.branchVersion != 2.6:
+			t.Errorf("Expected branchVersion to be 2.6, got %v", vr.branchVersion)
+		case vr.minVersion != 0:
+			t.Errorf("Expected minVersion to be 0, got %v", vr.minVersion)
+		case vr.maxVersion != 101:
+			t.Errorf("Expected maxVersion to be 101, got %v", vr.maxVersion)
+		}
+	})
+
+	t.Run("branchVersion is defined in the rules for branch: 2.5", func(t *testing.T) {
+		vr, err := GetVersionRules("2.5", false)
+		if err != nil {
+			t.Errorf("Unexpected error when branchVersion is defined in the rules: %v", err)
+		}
+		switch {
+		case vr.branchVersion != 2.5:
+			t.Errorf("Expected branchVersion to be 2.5, got %v", vr.branchVersion)
+		case vr.minVersion != 0:
+			t.Errorf("Expected minVersion to be 0, got %v", vr.minVersion)
+		case vr.maxVersion != 100:
+			t.Errorf("Expected maxVersion to be 100, got %v", vr.maxVersion)
+		}
+	})
+}

--- a/pkg/lifecycle/versions.rules.go
+++ b/pkg/lifecycle/versions.rules.go
@@ -19,6 +19,21 @@ type VersionRules struct {
 	maxVersion    int
 }
 
+func (vr *VersionRules) log(debug bool) {
+	if !debug {
+		return
+	}
+
+	for key, val := range vr.rules {
+		cycleLog(debug, "Branch version", key)
+		cycleLog(debug, "|- min version", val.min)
+		cycleLog(debug, "|- max version", val.max)
+	}
+	cycleLog(debug, "Applied rules for branch version", nil)
+	cycleLog(debug, "|-- min version", vr.minVersion)
+	cycleLog(debug, "|-- max version", vr.maxVersion)
+}
+
 // GetVersionRules will check and convert the provided branch version,
 // create the hard-coded rules for the charts repository and calculate the minimum and maximum versions according to the branch version.
 func GetVersionRules(branchVersion string, debug bool) (*VersionRules, error) {
@@ -50,6 +65,8 @@ func GetVersionRules(branchVersion string, debug bool) (*VersionRules, error) {
 
 	// Calculate the min and maximum versions allowed for the current branch version lifecycle
 	vr.getMinMaxVersionInts()
+
+	vr.log(debug)
 
 	return vr, err
 }

--- a/pkg/lifecycle/versions.rules.go
+++ b/pkg/lifecycle/versions.rules.go
@@ -1,0 +1,104 @@
+package lifecycle
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type version struct {
+	min string
+	max string
+}
+
+// VersionRules will hold all the necessary information to check which assets versions are allowed to be in the repository
+type VersionRules struct {
+	rules         map[float32]version
+	branchVersion float32
+	minVersion    int
+	maxVersion    int
+}
+
+// GetVersionRules will check and convert the provided branch version,
+// create the hard-coded rules for the charts repository and calculate the minimum and maximum versions according to the branch version.
+func GetVersionRules(branchVersion string, debug bool) (*VersionRules, error) {
+	if branchVersion == "" {
+		return nil, fmt.Errorf("branch version is empty")
+	}
+	// The rules are defined by the minimum and maximum version that the assets can have
+	var VersionRulesMap = map[float32]version{
+		2.9: {min: "104.0.0", max: "105.0.0"},
+		2.8: {min: "103.0.0", max: "104.0.0"},
+		2.7: {min: "101.0.0", max: "103.0.0"}, // 101 and 102, this is the only case like it
+		2.6: {min: "100.0.0", max: "101.0.0"},
+		2.5: {max: "100.0.0"},
+	}
+	// Just convert the string provided branch version to a float32
+	floatBranchVersion, err := convertBranchVersion(branchVersion)
+	if err != nil {
+		return nil, err
+	}
+	// Check if floatBranchVersion is an existing key in VersionRulesMap
+	if _, ok := VersionRulesMap[floatBranchVersion]; !ok {
+		return nil, fmt.Errorf("branch version %v is not defined in the rules", floatBranchVersion)
+	}
+
+	vr := &VersionRules{
+		rules:         VersionRulesMap,
+		branchVersion: floatBranchVersion,
+	}
+
+	// Calculate the min and maximum versions allowed for the current branch version lifecycle
+	vr.getMinMaxVersionInts()
+
+	return vr, err
+}
+
+// Current lifecycle rules are:
+//
+//	Branch can only hold until 2 previous versions of the current branch version.
+//	Branch cannot hold versions from newer branches, only older ones.
+//
+// See checkChartVersionForLifecycle() for more details.
+func (vr *VersionRules) getMinMaxVersionInts() {
+	// e.g: 2.9 - 0.2 = 2.7
+	minVersionStr := vr.rules[(vr.branchVersion - 0.2)].min
+	maxVersionStr := vr.rules[vr.branchVersion].max
+
+	// Don't check for errors here, these are hard-coded values
+	min, _ := strconv.Atoi(strings.Split(minVersionStr, ".")[0])
+	max, _ := strconv.Atoi(strings.Split(maxVersionStr, ".")[0])
+
+	vr.minVersion = min
+	vr.maxVersion = max
+	return
+}
+
+// convertBranchVersion will convert the received string flag into a float32
+func convertBranchVersion(branchVersion string) (float32, error) {
+	floatVersion, err := strconv.ParseFloat(branchVersion, 32)
+	if err != nil {
+		return 0.0, err
+	}
+	return float32(floatVersion), nil
+}
+
+// checkChartVersionForLifecycle will
+// Check if the chart version is within the range of the current version:
+//
+//	If the chart version is within the range, return true, otherwise return false
+func (vr *VersionRules) checkChartVersionForLifecycle(chartVersion string) bool {
+	chartVersionInt, _ := strconv.Atoi(strings.Split(chartVersion, ".")[0])
+	/**
+	Rule Example:
+	Branch version: 2.9
+	Min version: 104
+	Max version: 105
+	Therefore, the chart version must be >= (104 - 2) and < 105
+	i.e: 102 <= chartVersion < 105
+	*/
+	if chartVersionInt >= vr.minVersion && chartVersionInt < vr.maxVersion {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
### Context
After discussing we all agreed that we would maintain a newer lifecycle for assets version on `charts` as stated in the documentation:
[New Assets Lifecycle](https://github.com/rancher/charts/tree/prod-v2.9?tab=readme-ov-file#new-assets-lifecycle)

The new lifecycle will only be applied to **prod-v2.9+**

### Problem
It is a huge number of versions and assets, the work would be manual and prone to human errors. 

### Solution
Develop a script on `charts-build-scripts` to receive the branch version, calculate the rules and automatically remove all assets versions that do not belong to the lifecycle. 
