### PR TITLE
Add feature lifecycle-status

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -24,6 +24,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v4
         with:
           version: v1.57
+          args: --timeout 5m
 
   build:
     runs-on: ubuntu-latest

--- a/main.go
+++ b/main.go
@@ -257,6 +257,12 @@ func main() {
 			Action: lifecycleAssetsClean,
 			Flags:  []cli.Flag{branchVersionFlag, chartFlag, debugFlag},
 		},
+		{
+			Name:   "lifecycle-status",
+			Usage:  "Get the status of the current assets and charts based on the branch version and chart version according to the lifecycle rules",
+			Action: lifecycleStatus,
+			Flags:  []cli.Flag{branchVersionFlag, chartFlag},
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -569,5 +575,20 @@ func lifecycleAssetsClean(c *cli.Context) {
 	err = lifeCycleDep.ApplyRules(CurrentChart, DebugMode)
 	if err != nil {
 		logrus.Fatalf("Failed to apply versioning rules for lifecycle-assets-clean: %s", err)
+	}
+}
+
+func lifecycleStatus(c *cli.Context) {
+	// Initialize dependencies with branch-version and current chart
+	rootFs := filesystem.GetFilesystem(getRepoRoot())
+	lifeCycleDep, err := lifecycle.InitDependencies(rootFs, c.String("branch-version"), CurrentChart, false)
+	if err != nil {
+		logrus.Fatalf("encountered error while initializing dependencies for lifecycle-assets-clean: %s", err)
+	}
+
+	// Execute lifecycle status check and save the logs
+	err = lifeCycleDep.CheckLifecycleStatusAndSave(CurrentChart)
+	if err != nil {
+		logrus.Fatalf("Failed to check lifecycle status: %s", err)
 	}
 }

--- a/pkg/lifecycle/git.go
+++ b/pkg/lifecycle/git.go
@@ -4,8 +4,29 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+
+	"github.com/sirupsen/logrus"
 )
 
+type Git struct {
+	Dir string
+}
+
+// cloneAtDir clones a repository at a given directory
+func cloneAtDir(url, dir string) (*Git, error) {
+	logrus.Infof("Cloning repository %s into %s", url, dir)
+	cmd := exec.Command("git", "clone", "--depth", "1", url, dir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		logrus.Errorf("error while cloning repository: %s; err: %v", url, err)
+		return nil, fmt.Errorf("error while cloning repository: %s", err)
+	}
+	return &Git{Dir: dir}, nil
+}
+
+// checkIfGitIsClean checks if the git repository is clean and,
+// returns true if it is clean, false otherwise
 func checkIfGitIsClean(debug bool) (bool, error) {
 	cmd := exec.Command("git", "status", "--porcelain")
 	if debug {
@@ -24,8 +45,9 @@ func checkIfGitIsClean(debug bool) (bool, error) {
 	return true, nil
 }
 
+// gitAddAndCommit stages all changes and commits them with a given message,
+// equivalent to: git add -A && git commit -m message
 func gitAddAndCommit(message string) error {
-
 	// Stage all changes, including deletions
 	cmd := exec.Command("git", "add", "-A")
 	if err := cmd.Run(); err != nil {

--- a/pkg/lifecycle/git.go
+++ b/pkg/lifecycle/git.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Git struct holds necessary data to work with the current git repository
 type Git struct {
 	Dir string
 }
@@ -23,6 +24,38 @@ func cloneAtDir(url, dir string) (*Git, error) {
 		return nil, fmt.Errorf("error while cloning repository: %s", err)
 	}
 	return &Git{Dir: dir}, nil
+}
+
+// fetchAndCheckoutBranch fetches and checks out a branch
+func (g *Git) fetchAndCheckoutBranch(branch string) error {
+	logrus.Infof("Fetching and checking out at: %s", branch)
+	err := g.fetchBranch(branch)
+	if err != nil {
+		return err
+	}
+	return g.checkoutBranch(branch)
+}
+
+func (g *Git) fetchBranch(branch string) error {
+	cmd := exec.Command("git", "-C", g.Dir, "fetch", "origin", branch+":"+branch)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		logrus.Errorf("error while fetching branch: %s; err: %v", branch, err)
+		return fmt.Errorf("error while fetching branch: %s", err)
+	}
+	return nil
+}
+
+func (g *Git) checkoutBranch(branch string) error {
+	cmd := exec.Command("git", "-C", g.Dir, "checkout", branch)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		logrus.Errorf("error while checking out branch: %s; err: %v", branch, err)
+		return fmt.Errorf("error while checking out branch: %s", err)
+	}
+	return nil
 }
 
 // checkIfGitIsClean checks if the git repository is clean and,

--- a/pkg/lifecycle/logs.go
+++ b/pkg/lifecycle/logs.go
@@ -14,11 +14,8 @@ type logs struct {
 	filePath string
 }
 
-// SEPARATOR is a standard separator for logs
-const SEPARATOR = "\n"
-
-// ENDER is a standard end for the logged information
-const ENDER = "\n__________________________________________________________________\n"
+const separator = "\n"
+const ender = "\n__________________________________________________________________\n"
 
 // createLogs creates a new log file and returns a logs struct with the file and file path
 func createLogs(fileName string) (*logs, error) {
@@ -51,7 +48,7 @@ func (l *logs) writeHEAD(versionRules *VersionRules, title string) {
 	l.write(fmt.Sprintf("development branch: %s", versionRules.devBranch), "INFO")
 	l.write(fmt.Sprintf("production branch: %s", versionRules.prodBranch), "INFO")
 
-	rules := make(map[string]string)
+	rules := make(map[string]string, len(versionRules.rules))
 	for k, v := range versionRules.rules {
 		rules[fmt.Sprintf("%.1f", k)] = fmt.Sprintf("min: %s, max: %s", v.min, v.max)
 	}
@@ -84,13 +81,13 @@ func (l *logs) write(data string, logType string) {
 			logrus.Errorf("Error while writing logs: %s", err)
 		}
 	case "SEPARATE":
-		fmt.Printf(SEPARATOR)
-		if _, err := l.file.WriteString(SEPARATOR); err != nil {
+		fmt.Printf(separator)
+		if _, err := l.file.WriteString(separator); err != nil {
 			logrus.Errorf("Error while writing logs: %s", err)
 		}
 	case "END":
-		fmt.Printf(ENDER)
-		if _, err := l.file.WriteString("\n" + ENDER + "\n"); err != nil {
+		fmt.Printf(ender)
+		if _, err := l.file.WriteString("\n" + ender + "\n"); err != nil {
 			logrus.Errorf("Error while writing logs: %s", err)
 		}
 	default:

--- a/pkg/lifecycle/logs.go
+++ b/pkg/lifecycle/logs.go
@@ -1,0 +1,32 @@
+package lifecycle
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+type logs struct {
+	file     *os.File
+	filePath string
+}
+
+// createLogs creates a new log file and returns a logs struct with the file and file path
+func createLogs(fileName string) (*logs, error) {
+	filePath := fmt.Sprintf("logs/%s", fileName)
+
+	// Create the logs directory if it doesn't exist
+	err := os.MkdirAll("logs", 0755)
+	if err != nil {
+		logrus.Errorf("Error while creating logs directory: %s", err)
+	}
+
+	// Open the file in append mode
+	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	return &logs{file: file, filePath: filePath}, nil
+}

--- a/pkg/lifecycle/logs.go
+++ b/pkg/lifecycle/logs.go
@@ -1,8 +1,10 @@
 package lifecycle
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -11,6 +13,12 @@ type logs struct {
 	file     *os.File
 	filePath string
 }
+
+// SEPARATOR is a standard separator for logs
+const SEPARATOR = "\n"
+
+// ENDER is a standard end for the logged information
+const ENDER = "\n__________________________________________________________________\n"
 
 // createLogs creates a new log file and returns a logs struct with the file and file path
 func createLogs(fileName string) (*logs, error) {
@@ -29,4 +37,66 @@ func createLogs(fileName string) (*logs, error) {
 	}
 
 	return &logs{file: file, filePath: filePath}, nil
+}
+
+// writeHEAD writes the header of the log file with the version rules, dates and necessary information
+// to help analyze the current situation on the charts versions regarding the release process.
+func (l *logs) writeHEAD(versionRules *VersionRules, title string) {
+	l.write(title, "INFO")
+	currentTime := time.Now()
+	l.write(currentTime.Format("2006-01-02 15:04:05"), "INFO")
+	l.write(fmt.Sprintf("Branch Version: %.1f", versionRules.branchVersion), "INFO")
+	l.write(fmt.Sprintf("minimal version: %d", versionRules.minVersion), "INFO")
+	l.write(fmt.Sprintf("max version: %d", versionRules.maxVersion), "INFO")
+	l.write(fmt.Sprintf("development branch: %s", versionRules.devBranch), "INFO")
+	l.write(fmt.Sprintf("production branch: %s", versionRules.prodBranch), "INFO")
+
+	rules := make(map[string]string)
+	for k, v := range versionRules.rules {
+		rules[fmt.Sprintf("%.1f", k)] = fmt.Sprintf("min: %s, max: %s", v.min, v.max)
+	}
+
+	rulesJSON, err := json.MarshalIndent(rules, "", "    ")
+	if err != nil {
+		logrus.Errorf("JSON marshaling failed: %s", err)
+		l.write(fmt.Sprintf("rules: %v\n", versionRules.rules), "INFO")
+	} else {
+		l.write(fmt.Sprintf("rules: %s\n", rulesJSON), "INFO")
+	}
+}
+
+// write writes the data to the log file and prints it to the console with customizations.
+func (l *logs) write(data string, logType string) {
+	switch logType {
+	case "INFO":
+		logrus.Info(data)
+		if _, err := l.file.WriteString("INFO=" + data + "\n"); err != nil {
+			logrus.Errorf("Error while writing logs: %s", err)
+		}
+	case "WARN":
+		logrus.Warn(data)
+		if _, err := l.file.WriteString("WARN=" + data + "\n"); err != nil {
+			logrus.Errorf("Error while writing logs: %s", err)
+		}
+	case "ERROR":
+		logrus.Error(data)
+		if _, err := l.file.WriteString("ERROR=" + data + "\n"); err != nil {
+			logrus.Errorf("Error while writing logs: %s", err)
+		}
+	case "SEPARATE":
+		fmt.Printf(SEPARATOR)
+		if _, err := l.file.WriteString(SEPARATOR); err != nil {
+			logrus.Errorf("Error while writing logs: %s", err)
+		}
+	case "END":
+		fmt.Printf(ENDER)
+		if _, err := l.file.WriteString("\n" + ENDER + "\n"); err != nil {
+			logrus.Errorf("Error while writing logs: %s", err)
+		}
+	default:
+		fmt.Printf(data)
+		if _, err := l.file.WriteString(data + "\n"); err != nil {
+			logrus.Errorf("Error while writing logs: %s", err)
+		}
+	}
 }

--- a/pkg/lifecycle/logs.go
+++ b/pkg/lifecycle/logs.go
@@ -100,3 +100,15 @@ func (l *logs) write(data string, logType string) {
 		}
 	}
 }
+
+// writeVersions receives the loaded assets versions map and writes it to the log file
+// in human-readable format
+func (l *logs) writeVersions(assetsVersions map[string][]Asset, logType string) {
+	for asset, versions := range assetsVersions {
+		l.write("", "SEPARATE")
+		l.write(asset, logType)
+		for _, version := range versions {
+			l.write(version.version, "")
+		}
+	}
+}

--- a/pkg/lifecycle/status.go
+++ b/pkg/lifecycle/status.go
@@ -1,0 +1,23 @@
+package lifecycle
+
+// CheckLifecycleStatusAndSave checks the lifecycle status of the assets at 3 different levels:
+// 1. The current branch
+// 2. The comparison between production and development branches
+// 3. The separations of assets to be released and forward ported after the comparison in 2.
+func (ld *Dependencies) CheckLifecycleStatusAndSave(chart string) error {
+
+	// Get the status of the assets versions
+
+	// Create the logs infrastructure in the filesystem
+
+	// ##############################################################################
+	// Save the logs for the current branch
+
+	// ##############################################################################
+	// Save the logs for the comparison between production and development branches
+
+	// ##############################################################################
+	// Save the logs for the separations of assets to be released and forward ported
+
+	return nil
+}

--- a/pkg/lifecycle/status.go
+++ b/pkg/lifecycle/status.go
@@ -41,6 +41,7 @@ func (ld *Dependencies) getStatus() (*Status, error) {
 	}
 
 	// Separate the assets to be released from the assets to be forward ported after the comparison
+	status.separateReleaseFromForwardPort()
 
 	return status, nil
 }
@@ -261,4 +262,25 @@ func checkIfVersionIsReleased(version string, releasedVersions []Asset) bool {
 		}
 	}
 	return false
+}
+
+// separateReleaseFromForwardPort will separate the assets to be released from the assets to be forward ported, the assets were loaded previously by listProdAndDevAssets function.
+func (s *Status) separateReleaseFromForwardPort() {
+	assetsToBeReleased := make(map[string][]Asset)
+	assetsToBeForwardPorted := make(map[string][]Asset)
+
+	for asset, versions := range s.assetsNotReleasedInLifecycle {
+		for _, version := range versions {
+			if toRelease := s.ld.VR.CheckChartVersionToRelease(version.version); toRelease {
+				assetsToBeReleased[asset] = append(assetsToBeReleased[asset], version)
+			} else {
+				assetsToBeForwardPorted[asset] = append(assetsToBeForwardPorted[asset], version)
+			}
+		}
+	}
+
+	s.assetsToBeReleased = assetsToBeReleased
+	s.assetsToBeForwardPorted = assetsToBeForwardPorted
+
+	return
 }

--- a/pkg/lifecycle/status.go
+++ b/pkg/lifecycle/status.go
@@ -1,12 +1,48 @@
 package lifecycle
 
-// CheckLifecycleStatusAndSave checks the lifecycle status of the assets at 3 different levels:
-// 1. The current branch
-// 2. The comparison between production and development branches
-// 3. The separations of assets to be released and forward ported after the comparison in 2.
+import "github.com/sirupsen/logrus"
+
+// Status struct hold the results of the assets versions comparison,
+// this data will all be logged and saves into log files for further analysis
+type Status struct {
+	ld                              *Dependencies
+	assetsInLifecycleCurrentBranch  map[string][]Asset
+	assetsOutLifecycleCurrentBranch map[string][]Asset
+	assetsReleasedInLifecycle       map[string][]Asset // OK if not empty
+	assetsNotReleasedOutLifecycle   map[string][]Asset // OK if not empty
+	assetsNotReleasedInLifecycle    map[string][]Asset // WARN if not empty
+	assetsReleasedOutLifecycle      map[string][]Asset // ERROR if not empty
+	assetsToBeReleased              map[string][]Asset
+	assetsToBeForwardPorted         map[string][]Asset
+}
+
+// getStatus will create the Status object inheriting the Dependencies object and return it after:
+//
+//	list the current assets versions in the current branch
+//	list the production and development assets versions from the default branches
+//	separate the assets to be released from the assets to be forward ported
+func (ld *Dependencies) getStatus() (*Status, error) {
+	status := &Status{ld: ld}
+	// List the current assets versions in the current branch
+
+	// List the production and development assets versions comparisons from the default branches
+
+	// Separate the assets to be released from the assets to be forward ported after the comparison
+
+	return status, nil
+}
+
+// CheckLifecycleStatusAndSave checks the lifecycle status of the assets
+// at 3 different levels prints to the console and saves to log files at 'logs/' folder.
 func (ld *Dependencies) CheckLifecycleStatusAndSave(chart string) error {
 
 	// Get the status of the assets versions
+	status, err := ld.getStatus()
+	if err != nil {
+		logrus.Errorf("Error while getting the status: %s", err)
+		return err
+	}
+	_ = status // This will be removed in the future.
 
 	// Create the logs infrastructure in the filesystem
 

--- a/pkg/lifecycle/status.go
+++ b/pkg/lifecycle/status.go
@@ -177,7 +177,12 @@ func (s *Status) getProdAndDevAssetsFromGit(git *Git, tempDir string) (map[strin
 	tempDirRootFs := filesystem.GetFilesystem(tempDir)
 	tempHelmIndexPath := filesystem.GetAbsPath(tempDirRootFs, path.RepositoryHelmIndexFile)
 
-	// TODO: Fetch and checkout to the production branch
+	// Fetch and checkout to the production branch
+	err := git.fetchAndCheckoutBranch(s.ld.VR.prodBranch)
+	if err != nil {
+		logrus.Errorf("Error while fetching and checking out the production branch at: %s", err)
+		return nil, nil, err
+	}
 
 	// Get the map for the released assets versions on the production branch
 	releasedAssets, err := getAssetsMapFromIndex(tempHelmIndexPath, "", false)
@@ -186,7 +191,12 @@ func (s *Status) getProdAndDevAssetsFromGit(git *Git, tempDir string) (map[strin
 		return nil, nil, err
 	}
 
-	// TODO: Fetch and checkout to the development branch
+	// Fetch and checkout to the development branch
+	err = git.fetchAndCheckoutBranch(s.ld.VR.devBranch)
+	if err != nil {
+		logrus.Errorf("Error while fetching and checking out the development branch at: %s", err)
+		return nil, nil, err
+	}
 
 	// Get the map for the development assets versions on the development branch
 	devAssets, err := getAssetsMapFromIndex(tempHelmIndexPath, "", false)

--- a/pkg/lifecycle/status.go
+++ b/pkg/lifecycle/status.go
@@ -150,7 +150,7 @@ func (ld *Dependencies) CheckLifecycleStatusAndSave(chart string) error {
 	rfLogs.writeHEAD(status.ld.VR, "Assets to be released vs forward ported")
 	rfLogs.write("Assets to be RELEASED", "INFO")
 	rfLogs.writeVersions(status.assetsToBeReleased, "INFO")
-	cbLogs.write("", "END")
+	rfLogs.write("", "END")
 	rfLogs.write("Assets to be FORWARD-PORTED", "INFO")
 	rfLogs.writeVersions(status.assetsToBeForwardPorted, "INFO")
 

--- a/pkg/lifecycle/status.go
+++ b/pkg/lifecycle/status.go
@@ -118,12 +118,15 @@ func (ld *Dependencies) CheckLifecycleStatusAndSave(chart string) error {
 
 	// ##############################################################################
 	// Save the logs for the current branch
+	cbLogs.writeHEAD(status.ld.VR, "Assets versions vs the lifecycle rules in the current branch")
 
 	// ##############################################################################
 	// Save the logs for the comparison between production and development branches
+	pdLogs.writeHEAD(status.ld.VR, "Released assets vs development assets with lifecycle rules")
 
 	// ##############################################################################
 	// Save the logs for the separations of assets to be released and forward ported
+	rfLogs.writeHEAD(status.ld.VR, "Assets to be released vs forward ported")
 
 	return nil
 }

--- a/pkg/lifecycle/status.go
+++ b/pkg/lifecycle/status.go
@@ -106,6 +106,16 @@ func (ld *Dependencies) CheckLifecycleStatusAndSave(chart string) error {
 	defer pdLogs.file.Close()
 	defer rfLogs.file.Close()
 
+	// optional filter logs by specific chart
+	if chart != "" {
+		status.assetsInLifecycleCurrentBranch = map[string][]Asset{chart: status.assetsInLifecycleCurrentBranch[chart]}
+		status.assetsOutLifecycleCurrentBranch = map[string][]Asset{chart: status.assetsOutLifecycleCurrentBranch[chart]}
+		status.assetsReleasedInLifecycle = map[string][]Asset{chart: status.assetsReleasedInLifecycle[chart]}
+		status.assetsNotReleasedOutLifecycle = map[string][]Asset{chart: status.assetsNotReleasedOutLifecycle[chart]}
+		status.assetsNotReleasedInLifecycle = map[string][]Asset{chart: status.assetsNotReleasedInLifecycle[chart]}
+		status.assetsReleasedOutLifecycle = map[string][]Asset{chart: status.assetsReleasedOutLifecycle[chart]}
+	}
+
 	// ##############################################################################
 	// Save the logs for the current branch
 

--- a/pkg/lifecycle/status.go
+++ b/pkg/lifecycle/status.go
@@ -24,7 +24,7 @@ type Status struct {
 func (ld *Dependencies) getStatus() (*Status, error) {
 	status := &Status{ld: ld}
 	// List the current assets versions in the current branch
-
+	status.listCurrentAssetsVersionsOnTheCurrentBranch()
 	// List the production and development assets versions comparisons from the default branches
 
 	// Separate the assets to be released from the assets to be forward ported after the comparison
@@ -56,4 +56,28 @@ func (ld *Dependencies) CheckLifecycleStatusAndSave(chart string) error {
 	// Save the logs for the separations of assets to be released and forward ported
 
 	return nil
+}
+
+// listCurrentAssetsVersionsOnTheCurrentBranch returns the Status struct by reference
+// with 2 maps of assets versions, one for the assets that are in the lifecycle,
+// and another for the assets that are outside of the lifecycle.
+func (s *Status) listCurrentAssetsVersionsOnTheCurrentBranch() {
+	insideLifecycle := make(map[string][]Asset)
+	outsideLifecycle := make(map[string][]Asset)
+
+	for asset, versions := range s.ld.assetsVersionsMap {
+		for _, version := range versions {
+			inLifecycle := s.ld.VR.CheckChartVersionForLifecycle(version.version)
+			if inLifecycle {
+				insideLifecycle[asset] = append(insideLifecycle[asset], version)
+			} else {
+				outsideLifecycle[asset] = append(outsideLifecycle[asset], version)
+			}
+		}
+	}
+
+	s.assetsInLifecycleCurrentBranch = insideLifecycle
+	s.assetsOutLifecycleCurrentBranch = outsideLifecycle
+
+	return
 }

--- a/pkg/lifecycle/status.go
+++ b/pkg/lifecycle/status.go
@@ -1,6 +1,10 @@
 package lifecycle
 
-import "github.com/sirupsen/logrus"
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
 
 // Status struct hold the results of the assets versions comparison,
 // this data will all be logged and saves into log files for further analysis
@@ -23,9 +27,16 @@ type Status struct {
 //	separate the assets to be released from the assets to be forward ported
 func (ld *Dependencies) getStatus() (*Status, error) {
 	status := &Status{ld: ld}
+
 	// List the current assets versions in the current branch
 	status.listCurrentAssetsVersionsOnTheCurrentBranch()
+
 	// List the production and development assets versions comparisons from the default branches
+	err := status.listProdAndDevAssets()
+	if err != nil {
+		logrus.Errorf("Error while comparing production and development branches: %s", err)
+		return status, err
+	}
 
 	// Separate the assets to be released from the assets to be forward ported after the comparison
 
@@ -80,4 +91,73 @@ func (s *Status) listCurrentAssetsVersionsOnTheCurrentBranch() {
 	s.assetsOutLifecycleCurrentBranch = outsideLifecycle
 
 	return
+}
+
+// listProdAndDevAssets will clone the charts repository at a temporary directory,
+// fetch and checkout in the production and development branches for the given version,
+// get the assets versions from the index.yaml file and compare the assets versions,
+// separating into 4 different maps for further analysis.
+func (s *Status) listProdAndDevAssets() error {
+	// Create and destroy a temporary directory structure
+	defaultWorkingDir, tempDir, err := createTemporaryDirStructure()
+	if err != nil {
+		logrus.Errorf("Error while creating temporary dir structure: %s", err)
+		return err
+	}
+	defer destroyTemporaryDirStructure(defaultWorkingDir, tempDir)
+
+	// Clone the repository at the temporary directory
+	git, err := cloneAtDir("https://github.com/rancher/charts", tempDir)
+	if err != nil {
+		return err
+	}
+
+	_ = git // this will be removed in the future
+
+	// Fetch, checkout and map assets versions in the production and development branches
+
+	// Compare the assets versions between the production and development branches
+	return nil
+}
+
+// createTemporaryDirStructure creates a temporary directory structure and changes the working directory to it returning the path for both folders.
+func createTemporaryDirStructure() (string, string, error) {
+	// Save the current working directory for changing back to it later
+	defaultWorkingDir, err := os.Getwd()
+	if err != nil {
+		logrus.Errorf("Error while getting the current working directory: %s", err)
+		return "", "", err
+	}
+
+	// Create the temporary directory
+	tempDir, err := os.MkdirTemp("", "temporaryDir")
+	if err != nil {
+		return "", "", err
+	}
+
+	// change the workind directory to the temporary one
+	err = os.Chdir(tempDir)
+	if err != nil {
+		logrus.Errorf("Error while changing working directory to temporary directory: %v", err)
+		return defaultWorkingDir, tempDir, err
+	}
+	return defaultWorkingDir, tempDir, nil
+}
+
+// destroyTemporaryDirStructure destroys the temporary directory and changes the working directory back to the default one.
+func destroyTemporaryDirStructure(defaultWorkingDir, tempDir string) error {
+	// Change the directory back to the default working directory
+	err := os.Chdir(defaultWorkingDir)
+	if err != nil {
+		logrus.Errorf("Error while changing back to default working directory: %v", err)
+		return err
+	}
+
+	// Remove the temporary directory
+	err = os.RemoveAll(tempDir)
+	if err != nil {
+		logrus.Errorf("Error while removing temporary directory: %v", err)
+		return err
+	}
+	return nil
 }

--- a/pkg/lifecycle/versions.rules.go
+++ b/pkg/lifecycle/versions.rules.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 // ProductionBranchPrefix is the official prefix for the production branch
@@ -138,10 +140,11 @@ func (vr *VersionRules) CheckChartVersionForLifecycle(chartVersion string) bool 
 }
 
 // CheckChartVersionToRelease will return if the current versyion being analyzed is the one to be released or not
-func (vr *VersionRules) CheckChartVersionToRelease(chartVersion string) bool {
-	chartVersionInt, _ := strconv.Atoi(strings.Split(chartVersion, ".")[0])
-	if chartVersionInt == (vr.maxVersion - 1) {
-		return true
+func (vr *VersionRules) CheckChartVersionToRelease(chartVersion string) (bool, error) {
+	chartVersionInt, err := strconv.Atoi(strings.Split(chartVersion, ".")[0])
+	if err != nil {
+		logrus.Errorf("failed to check version to release for chartVersion:%s with error:%v", chartVersion, err)
+		return false, err
 	}
-	return false
+	return chartVersionInt == (vr.maxVersion - 1), nil
 }

--- a/pkg/lifecycle/versions.rules.go
+++ b/pkg/lifecycle/versions.rules.go
@@ -6,6 +6,12 @@ import (
 	"strings"
 )
 
+// ProductionBranchPrefix is the official prefix for the production branch
+const ProductionBranchPrefix = "prod-v"
+
+// DevBranchPrefix is the official prefix for the development branch
+const DevBranchPrefix = "dev-v"
+
 type version struct {
 	min string
 	max string
@@ -17,6 +23,8 @@ type VersionRules struct {
 	branchVersion float32
 	minVersion    int
 	maxVersion    int
+	devBranch     string
+	prodBranch    string
 }
 
 func (vr *VersionRules) log(debug bool) {
@@ -65,6 +73,9 @@ func GetVersionRules(branchVersion string, debug bool) (*VersionRules, error) {
 
 	// Calculate the min and maximum versions allowed for the current branch version lifecycle
 	vr.getMinMaxVersionInts()
+
+	vr.prodBranch = fmt.Sprintf("%s%.1f", ProductionBranchPrefix, vr.branchVersion)
+	vr.devBranch = fmt.Sprintf("%s%.1f", DevBranchPrefix, vr.branchVersion)
 
 	vr.log(debug)
 
@@ -121,6 +132,15 @@ func (vr *VersionRules) CheckChartVersionForLifecycle(chartVersion string) bool 
 	i.e: 102 <= chartVersion < 105
 	*/
 	if chartVersionInt >= vr.minVersion && chartVersionInt < vr.maxVersion {
+		return true
+	}
+	return false
+}
+
+// CheckChartVersionToRelease will return if the current versyion being analyzed is the one to be released or not
+func (vr *VersionRules) CheckChartVersionToRelease(chartVersion string) bool {
+	chartVersionInt, _ := strconv.Atoi(strings.Split(chartVersion, ".")[0])
+	if chartVersionInt == (vr.maxVersion - 1) {
 		return true
 	}
 	return false


### PR DESCRIPTION
### Problem and Context

At [charts-repo](https://github.com/rancher/charts) we need to inspect which versions should be released or forward-ported at new release cycles.
This is not a problem in usual release cycles, where we have around 10 charts on average. 
But when we are creating a new branch for a new version of Rancher (e.g., 2.9), we start to have many charts and versions to inspect. 

We have up to 20 charts, each with at least 20 versions, so visually inspecting the versions becomes more difficult. 
After we decided to implement the new lifecycle rules, this got really hard. 

---

### Solution
Implement a **CLI** feature for `charts-build-scripts` that can:
- list and analyze the current asset versions
- list and compare the asset versions at the official development and production branches
- list which charts should be forward-ported and/or released from the dev to the production branch. 

All this listing must be made against the lifecycle rules in place defined at [LifecycleRules](https://github.com/rancher/charts?tab=readme-ov-file#new-assets-lifecycle)

The objects in the functions must be re-usable by other functions in `charts-build-scripts` to automate the release and forward-port process in the near future. 

---

### Results

These are 3 log files samples generated by this implementation:
`2024-06-20T18:06__current-branch.log`:
```
INFO=Assets versions vs the lifecycle rules in the current branch
INFO=2024-06-20 18:06:00
INFO=Branch Version: 2.9
INFO=minimal version: 101
INFO=max version: 105
INFO=development branch: dev-v2.9
INFO=production branch: prod-v2.9
INFO=rules: {
    "2.5": "min: , max: 100.0.0",
    "2.6": "min: 100.0.0, max: 101.0.0",
    "2.7": "min: 101.0.0, max: 103.0.0",
    "2.8": "min: 103.0.0, max: 104.0.0",
    "2.9": "min: 104.0.0, max: 105.0.0"
}

INFO=Versions INSIDE the lifecycle in the current branch

INFO=rancher-alerting-drivers
104.0.0-rc1
103.0.2
103.0.1
103.0.0
102.1.2
102.1.1
102.1.0
102.0.0
101.0.0

INFO=longhorn
103.3.1+up1.6.2
103.3.0+up1.6.1
103.2.3+up1.5.5
103.2.2+up1.5.4
103.2.1+up1.5.3
```

`2024-06-20T18:06__production-compare-development.log`:
```
INFO=Released assets vs development assets with lifecycle rules
INFO=2024-06-20 18:06:04
INFO=Branch Version: 2.9
INFO=minimal version: 101
INFO=max version: 105
INFO=development branch: dev-v2.9
INFO=production branch: prod-v2.9
INFO=rules: {
    "2.5": "min: , max: 100.0.0",
    "2.6": "min: 100.0.0, max: 101.0.0",
    "2.7": "min: 101.0.0, max: 103.0.0",
    "2.8": "min: 103.0.0, max: 104.0.0",
    "2.9": "min: 104.0.0, max: 105.0.0"
}

INFO=Assets RELEASED and Inside the lifecycle
INFO=At the production branch: prod-v2.9

INFO=system-upgrade-controller
103.0.0+up0.6.0
102.1.0+up0.5.0
102.0.0+up0.4.0
101.0.0+up0.3.3

INFO=rancher-gke-operator
103.0.1+up1.2.0
102.0.2+up1.1.6
102.0.0+up1.1.5
101.0.0+up1.1.5

INFO=rancher-istio
103.0.0+up1.18.2
102.3.1+up1.18.2
102.3.0+up1.18.2
102.2.0+up1.17.2
102.1.0+up1.16.3
102.0.0+up1.15.3
101.0.0+up1.14.3
```

`2024-06-20T18:06__released-forward-ported.log`:
```
INFO=Assets to be released vs forward ported
INFO=2024-06-20 18:06:04
INFO=Branch Version: 2.9
INFO=minimal version: 101
INFO=max version: 105
INFO=development branch: dev-v2.9
INFO=production branch: prod-v2.9
INFO=rules: {
    "2.5": "min: , max: 100.0.0",
    "2.6": "min: 100.0.0, max: 101.0.0",
    "2.7": "min: 101.0.0, max: 103.0.0",
    "2.8": "min: 103.0.0, max: 104.0.0",
    "2.9": "min: 104.0.0, max: 105.0.0"
}

INFO=Assets to be RELEASED

INFO=rancher-gke-operator
104.0.0+up1.9.0-rc.4

INFO=harvester-csi-driver
104.0.0+up0.1.17

INFO=elemental
104.0.0+up1.4.3

INFO=rancher-backup
104.0.0+up5.0.0-rc.6

INFO=elemental-crd
104.0.0+up1.4.3

INFO=fleet
104.0.0+up0.10.0-rc.17
```