### PR TITLE
Fix crd patches

### DIFF
--- a/pkg/charts/additionalchart.go
+++ b/pkg/charts/additionalchart.go
@@ -48,8 +48,10 @@ func (c *AdditionalChart) ApplyMainChanges(pkgFs billy.Filesystem) error {
 	if err != nil {
 		return fmt.Errorf("encountered error while trying to get the main chart's working directory: %s", err)
 	}
-	if err := helm.CopyCRDsFromChart(pkgFs, mainChartWorkingDir, path.ChartCRDDir, c.WorkingDir, c.CRDChartOptions.CRDDirectory); err != nil {
-		return fmt.Errorf("encountered error while trying to copy CRDs from %s to %s: %s", mainChartWorkingDir, c.WorkingDir, err)
+	if c.Upstream == nil {
+		if err := helm.DeleteCRDsFromChart(pkgFs, mainChartWorkingDir); err != nil {
+			return fmt.Errorf("encountered error while trying to delete CRDs from main chart: %s", err)
+		}
 	}
 	if c.CRDChartOptions.AddCRDValidationToMainChart {
 		if err := AddCRDValidationToChart(pkgFs, mainChartWorkingDir, c.WorkingDir, c.CRDChartOptions.CRDDirectory); err != nil {
@@ -57,7 +59,7 @@ func (c *AdditionalChart) ApplyMainChanges(pkgFs billy.Filesystem) error {
 		}
 	}
 	if c.CRDChartOptions.UseTarArchive {
-		if err := helm.ArchiveCRDs(pkgFs, mainChartWorkingDir, path.ChartCRDDir, c.WorkingDir, path.ChartExtraFileDir); err != nil {
+		if err := helm.ArchiveCRDs(pkgFs, c.WorkingDir, c.CRDChartOptions.CRDDirectory, c.WorkingDir, path.ChartExtraFileDir); err != nil {
 			return fmt.Errorf("encountered error while trying to bundle and compress CRD files from the main chart: %s", err)
 		}
 
@@ -88,7 +90,7 @@ func (c *AdditionalChart) RevertMainChanges(pkgFs billy.Filesystem) error {
 		return fmt.Errorf("encountered error while trying to get the main chart's working directory: %s", err)
 	}
 	if c.CRDChartOptions.UseTarArchive {
-		if err := filesystem.UnarchiveTgz(pkgFs, filepath.Join(c.WorkingDir, path.ChartExtraFileDir, path.ChartCRDTgzFilename), "", filepath.Join(c.WorkingDir, c.CRDChartOptions.CRDDirectory), false); err != nil {
+		if err := filesystem.UnarchiveTgz(pkgFs, filepath.Join(c.WorkingDir, path.ChartExtraFileDir, path.ChartCRDTgzFilename), "crds", filepath.Join(c.WorkingDir, c.CRDChartOptions.CRDDirectory), false); err != nil {
 			return fmt.Errorf("encountered error while trying to unarchive CRD files from %s: %s", filepath.Join(c.WorkingDir, "files", path.ChartCRDTgzFilename), err)
 		}
 	}
@@ -122,27 +124,33 @@ func (c *AdditionalChart) Prepare(rootFs, pkgFs billy.Filesystem, mainChartUpstr
 		return fmt.Errorf("encountered error while trying to clean up %s before preparing: %s", c.WorkingDir, err)
 	}
 	if c.CRDChartOptions != nil {
+		if err := GenerateCRDChartFromTemplate(pkgFs, c.WorkingDir, filepath.Join(path.PackageTemplatesDir, c.CRDChartOptions.TemplateDirectory), c.CRDChartOptions.CRDDirectory); err != nil {
+			return fmt.Errorf("encountered error while trying to generate CRD chart from template at %s: %s", c.CRDChartOptions.TemplateDirectory, err)
+		}
+
 		c.upstreamChartVersion = mainChartUpstreamVersion
 		mainChartWorkingDir, err := c.getMainChartWorkingDir(pkgFs)
 		if err != nil {
 			return fmt.Errorf("encountered error while trying to get the main chart's working directory: %s", err)
 		}
+
 		if c.Upstream != nil {
 			logrus.Infof("pulling CRD upstream")
 			u := *c.Upstream
-			if err := u.Pull(rootFs, pkgFs, filepath.Join(mainChartWorkingDir, path.ChartCRDDir)); err != nil {
+			if err := u.Pull(rootFs, pkgFs, filepath.Join(c.WorkingDir, path.ChartCRDDir)); err != nil {
 				return fmt.Errorf("encountered error while trying to pull upstream into %s: %s", mainChartWorkingDir, err)
 			}
-		}
-		exists, err := filesystem.PathExists(pkgFs, filepath.Join(mainChartWorkingDir, path.ChartCRDDir))
-		if err != nil {
-			return fmt.Errorf("encountered error while trying to check if %s exists: %s", filepath.Join(mainChartWorkingDir, path.ChartCRDDir), err)
-		}
-		if !exists {
-			return fmt.Errorf("unable to prepare a CRD chart since there are no CRDs at %s", filepath.Join(mainChartWorkingDir, path.ChartCRDDir))
-		}
-		if err := GenerateCRDChartFromTemplate(pkgFs, c.WorkingDir, filepath.Join(path.PackageTemplatesDir, c.CRDChartOptions.TemplateDirectory), c.CRDChartOptions.CRDDirectory); err != nil {
-			return fmt.Errorf("encountered error while trying to generate CRD chart from template at %s: %s", c.CRDChartOptions.TemplateDirectory, err)
+		} else {
+			exists, err := filesystem.PathExists(pkgFs, filepath.Join(mainChartWorkingDir, path.ChartCRDDir))
+			if err != nil {
+				return fmt.Errorf("encountered error while trying to check if %s exists: %s", filepath.Join(mainChartWorkingDir, path.ChartCRDDir), err)
+			}
+			if !exists {
+				return fmt.Errorf("unable to prepare a CRD chart since there are no CRDs at %s", filepath.Join(mainChartWorkingDir, path.ChartCRDDir))
+			}
+			if err := helm.CopyCRDsFromChart(pkgFs, mainChartWorkingDir, path.ChartCRDDir, c.WorkingDir, c.CRDChartOptions.CRDDirectory); err != nil {
+				return fmt.Errorf("encountered error while trying to copy CRDs from %s to %s: %s", mainChartWorkingDir, c.WorkingDir, err)
+			}
 		}
 	} else {
 		u := *c.Upstream

--- a/pkg/charts/additionalchart.go
+++ b/pkg/charts/additionalchart.go
@@ -89,14 +89,16 @@ func (c *AdditionalChart) RevertMainChanges(pkgFs billy.Filesystem) error {
 	if err != nil {
 		return fmt.Errorf("encountered error while trying to get the main chart's working directory: %s", err)
 	}
-	if c.CRDChartOptions.UseTarArchive {
-		if err := filesystem.UnarchiveTgz(pkgFs, filepath.Join(c.WorkingDir, path.ChartExtraFileDir, path.ChartCRDTgzFilename), "crds", filepath.Join(c.WorkingDir, c.CRDChartOptions.CRDDirectory), false); err != nil {
-			return fmt.Errorf("encountered error while trying to unarchive CRD files from %s: %s", filepath.Join(c.WorkingDir, "files", path.ChartCRDTgzFilename), err)
+	if c.Upstream == nil {
+		if c.CRDChartOptions.UseTarArchive {
+			if err := filesystem.UnarchiveTgz(pkgFs, filepath.Join(c.WorkingDir, path.ChartExtraFileDir, path.ChartCRDTgzFilename), "crds", filepath.Join(c.WorkingDir, c.CRDChartOptions.CRDDirectory), false); err != nil {
+				return fmt.Errorf("encountered error while trying to unarchive CRD files from %s: %s", filepath.Join(c.WorkingDir, "files", path.ChartCRDTgzFilename), err)
+			}
 		}
-	}
-	// copy CRD files from packages/<package>/<workingDir>/<crdDirectory>/ back to packages/<package>/crds/
-	if err := helm.CopyCRDsFromChart(pkgFs, c.WorkingDir, c.CRDChartOptions.CRDDirectory, mainChartWorkingDir, path.ChartCRDDir); err != nil {
-		return fmt.Errorf("encountered error while trying to copy CRDs from %s to %s: %s", c.WorkingDir, mainChartWorkingDir, err)
+		// copy CRD files from packages/<package>/<workingDir>/<crdDirectory>/ back to packages/<package>/crds/
+		if err := helm.CopyCRDsFromChart(pkgFs, c.WorkingDir, c.CRDChartOptions.CRDDirectory, mainChartWorkingDir, path.ChartCRDDir); err != nil {
+			return fmt.Errorf("encountered error while trying to copy CRDs from %s to %s: %s", c.WorkingDir, mainChartWorkingDir, err)
+		}
 	}
 	if c.CRDChartOptions.AddCRDValidationToMainChart {
 		if err := RemoveCRDValidationFromChart(pkgFs, mainChartWorkingDir); err != nil {


### PR DESCRIPTION
## Problem

When generating patches for a chart with crds we currently copy the crds pulled from upstream back into the main chart which are then included in the main chart patch.

## Solution

We can't simply check for `c.Upstream == nil` before copying since we will not be able to generate `validate-install-crd.yaml` when `c.CRDOptions.UseTarArchive` is `true` since there won't be any crds to generate the validation on. To fix this, we always generate the validation file based on the crds in the generated chart and only copy those crds to the main chart if there is no upstream.

Unfortunately we have to unarchive the CRDs whenever we need to generate the validation file, but in my testing this does not affect the runtime much. I think the better separation between the `Prepare`, `ApplyMainChanges`, and `RevertMainChanges` makes up for it in terms of readbility. (of course open to disagreement on this point)

Issue: https://github.com/rancher/charts-build-scripts/issues/142