### PR TITLE
fixing bug by adding check for not exist

### DIFF
--- a/pkg/auto/release.go
+++ b/pkg/auto/release.go
@@ -92,7 +92,7 @@ func (r *Release) PullAsset() error {
 }
 
 func checkAssetReleased(chartVersion string) error {
-	if _, err := os.Stat(chartVersion); err != nil {
+	if _, err := os.Stat(chartVersion); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 


### PR DESCRIPTION
There was a bug on the check for the already released charts, just fixing it by checking the type of the error also. 