### PR TITLE
Validate release charts

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,7 +47,11 @@ const (
 	// defaultForkEnvironmentVariable is the default environment variable that indicates the fork URL
 	defaultForkEnvironmentVariable = "FORK"
 	// defaultChartVersionEnvironmentVariable is the default environment variable that indicates the version to release
-	defaultChartVersionEnvironmentVariable = ""
+	defaultChartVersionEnvironmentVariable = "CHART_VERSION"
+	// defaultGHTokenEnvironmentVariable is the default environment variable that indicates the Github Auth token
+	defaultGHTokenEnvironmentVariable = "GH_TOKEN"
+	// defaultPRNumberEnvironmentVariable is the default environment variable that indicates the PR number
+	defaultPRNumberEnvironmentVariable = "PR_NUMBER"
 )
 
 var (
@@ -58,8 +62,6 @@ var (
 
 	// ChartsScriptOptionsFile represents a name of a file that contains options for the charts script to use for this branch
 	ChartsScriptOptionsFile string
-	// GithubToken represents the Github Auth token; currently not used
-	GithubToken string
 	// CurrentPackage represents the specific package to apply the scripts to
 	CurrentPackage string
 	// CurrentChart represents a specific chart to apply the scripts to. Also accepts a specific version.
@@ -80,6 +82,10 @@ var (
 	ChartVersion = ""
 	// Branch repsents the branch to compare against
 	Branch = ""
+	// PullRequest represents the Pull Request identifying number
+	PullRequest = ""
+	// GithubToken represents the Github Auth token
+	GithubToken string
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -767,13 +767,16 @@ func release(c *cli.Context) {
 
 func validateRelease(c *cli.Context) {
 	if GithubToken == "" {
-		logrus.Fatal("GH_TOKEN environment variable must be set to run validate-release-charts")
+		fmt.Println("GH_TOKEN environment variable must be set to run validate-release-charts")
+		os.Exit(1)
 	}
 	if PullRequest == "" {
-		logrus.Fatal("PR_NUMBER environment variable must be set to run validate-release-charts")
+		fmt.Println("PR_NUMBER environment variable must be set to run validate-release-charts")
+		os.Exit(1)
 	}
 	if Branch == "" {
-		logrus.Fatal("BRANCH environment variable must be set to run validate-release-charts")
+		fmt.Println("BRANCH environment variable must be set to run validate-release-charts")
+		os.Exit(1)
 	}
 
 	r := filesystem.GetFilesystem(getRepoRoot())
@@ -785,10 +788,12 @@ func validateRelease(c *cli.Context) {
 
 	d, err := lifecycle.InitDependencies(r, strings.TrimPrefix(Branch, "release-v"), "")
 	if err != nil {
-		logrus.Fatalf("encountered error while initializing d: %v", err)
+		fmt.Printf("encountered error while initializing d: %v \n", err)
+		os.Exit(1)
 	}
 
 	if err := auto.ValidatePullRequest(GithubToken, PullRequest, d); err != nil {
-		logrus.Fatalf("failed to validate pull request: %v", err)
+		fmt.Printf("failed to validate pull request: %v \n", err)
+		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -174,7 +174,7 @@ func main() {
 		Name: "version",
 		Usage: `Usage:
 			./bin/charts-build-scripts <command> --version="<chart_version>"
-			VERSION="<chart_version>" make <command>
+			CHART_VERSION="<chart_version>" make <command>
 
 		Target version of chart to release.
 		`,

--- a/main.go
+++ b/main.go
@@ -328,6 +328,50 @@ func main() {
 			Action: release,
 			Flags:  []cli.Flag{branchVersionFlag, chartFlag, chartVersionFlag, forkFlag},
 		},
+		{
+			Name: "validate-release-charts",
+			Usage: `Check charts to release in PR.
+			`,
+			Action: validateRelease,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name: "branch,b",
+					Usage: `Usage:
+					./bin/charts-build-scripts <command> --branch="release-v2.y"
+					BRANCH="release-v2.y" make <command>
+
+					Available branches for release: (release-v2.8; release-v2.9; release-v2.10...)
+					`,
+					Required:    true,
+					EnvVar:      defaultBranchEnvironmentVariable,
+					Destination: &Branch,
+				},
+				cli.StringFlag{
+					Name: "gh_token",
+					Usage: `Usage:
+					./bin/charts-build-scripts <command> --gh_token="********"
+					GH_TOKEN="*********" make <command>
+
+					Github Auth Token provided by Github Actions job
+					`,
+					Required:    true,
+					EnvVar:      defaultGHTokenEnvironmentVariable,
+					Destination: &GithubToken,
+				},
+				cli.StringFlag{
+					Name: "pr_number",
+					Usage: `Usage:
+					./bin/charts-build-scripts <command> --pr_number="****"
+					PR_NUMBER="****" make <command>
+
+					Pull Request identifying number provided by Github Actions job
+					`,
+					Required:    true,
+					EnvVar:      defaultPRNumberEnvironmentVariable,
+					Destination: &PullRequest,
+				},
+			},
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/pkg/auto/validate.go
+++ b/pkg/auto/validate.go
@@ -48,8 +48,11 @@ func loadPullRequestValidation(token, prNum string, dep *lifecycle.Dependencies)
 	}
 
 	pr, resp, err := gitClient.PullRequests.Get(ctx, owner, repo, pNum)
-	if err != nil || resp.StatusCode != 200 {
+	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("failed to get pull request, status code: %s", resp.Status)
 	}
 
 	prFiles, _, err := gitClient.PullRequests.ListFiles(ctx, owner, repo, pNum, nil)

--- a/pkg/auto/validate.go
+++ b/pkg/auto/validate.go
@@ -1,0 +1,169 @@
+package auto
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/Masterminds/semver"
+	"github.com/google/go-github/v41/github"
+	"github.com/rancher/charts-build-scripts/pkg/lifecycle"
+	"github.com/rancher/charts-build-scripts/pkg/options"
+	"github.com/rancher/charts-build-scripts/pkg/path"
+	"golang.org/x/oauth2"
+)
+
+// Referred to: https://github.com/rancher/charts
+const owner = "rancher"
+const repo = "charts"
+
+var (
+	errReleaseYaml       error = errors.New("release.yaml errors")
+	errModifiedChart     error = errors.New("released chart cannot be modified")
+	errMinorPatchVersion error = errors.New("chart version must be exactly 1 more patch/minor version than the previous chart version")
+)
+
+// validation struct will hold the pull request and its files to be validated.
+type validation struct {
+	pr    *github.PullRequest
+	files []*github.CommitFile
+	dep   *lifecycle.Dependencies
+}
+
+// loadPullRequestValidation will load the pull request validation struct with the pull request and its files.
+// it will also load the dependencies struct with the filesystem, assets versions map, version rules and methods to enforce the lifecycle rules in the given branch.
+func loadPullRequestValidation(token, prNum string, dep *lifecycle.Dependencies) (*validation, error) {
+	ctx := context.Background()
+
+	tokenSource := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	tokenClient := oauth2.NewClient(ctx, tokenSource)
+	gitClient := github.NewClient(tokenClient)
+
+	pNum, err := strconv.Atoi(prNum)
+	if err != nil {
+		return nil, err
+	}
+
+	pr, resp, err := gitClient.PullRequests.Get(ctx, owner, repo, pNum)
+	if err != nil || resp.StatusCode != 200 {
+		return nil, err
+	}
+
+	prFiles, _, err := gitClient.PullRequests.ListFiles(ctx, owner, repo, pNum, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &validation{pr, prFiles, dep}, nil
+}
+
+// ValidatePullRequest will execute the check a given pull request for the following:
+//   - Checkpoint 0: release.yaml file is valid
+//   - TODO: Checkpoint 1: Compare contents of assets/ to charts/
+//   - TODO: Checkpoint 2: Compare assets against index.yaml
+func ValidatePullRequest(token, prNum string, dep *lifecycle.Dependencies) error {
+
+	v, err := loadPullRequestValidation(token, prNum, dep)
+	if err != nil {
+		return err
+	}
+
+	// Checkpoint 0
+	releaseOpts, err := options.LoadReleaseOptionsFromFile(dep.RootFs, path.RepositoryReleaseYaml)
+	if err != nil {
+		return err
+	}
+	if err := v.validateReleaseYaml(releaseOpts); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateReleaseYaml will validate the release.yaml file for:
+//   - each chart version in release.yaml does not modify an already released chart.
+//   - each chart version in release.yaml is exactly 1 more patch/minor version than the previous chart version if the chart is being released.
+//   - each chart version in release.yaml that is being forward-ported is within the range of the current branch version.
+func (v *validation) validateReleaseYaml(releaseOpts options.ReleaseOptions) error {
+	assetFilePaths := make(map[string]string, len(releaseOpts))
+
+	for chart, versions := range releaseOpts {
+		for _, version := range versions {
+			// save this for checking modified charts later
+			assetFilePath := "assets/" + chart + "/" + chart + "-" + version + ".tgz"
+			assetFilePaths[assetFilePath] = version
+
+			// check patch/minor version update if not net-new chart
+			releasedVersions := v.dep.AssetsVersionsMap[chart]
+			if len(releasedVersions) <= 1 {
+				continue // net-new chart
+			}
+			latestReleasedVersion := releasedVersions[1].Version
+			if err := v.checkMinorPatchVersion(version, latestReleasedVersion); err != nil {
+				return err
+			}
+		}
+	}
+
+	return v.checkNeverModifyReleasedChart(assetFilePaths)
+}
+
+// checkMinorPatchVersion will check if the chart version is exactly 1 more patch/minor version than the previous chart version or if the chart is being released. If the chart is being forward-ported, this validation is skipped.
+func (v *validation) checkMinorPatchVersion(version string, latestReleasedVersion string) error {
+	// check if the chart version is being released or forward-ported
+	release, err := v.dep.VR.CheckChartVersionToRelease(version)
+	if err != nil {
+		return err
+	}
+	// skip this validation for forward-ported charts
+	if !release {
+		return nil
+	}
+
+	// Parse the versions
+	latestVer, err := semver.NewVersion(latestReleasedVersion)
+	if err != nil {
+		return err
+	}
+	newVer, err := semver.NewVersion(version)
+	if err != nil {
+		return err
+	}
+
+	// calculate the version bumps
+	minorDiff := newVer.Minor() - latestVer.Minor()
+	patchDiff := newVer.Patch() - latestVer.Patch()
+
+	// the version bump must be exactly 1 more patch or minor version than the previous chart version
+	if minorDiff > 1 || patchDiff > 1 || minorDiff > 0 && patchDiff > 0 {
+		return fmt.Errorf("%w; version: %s; latest version: %s", errMinorPatchVersion, version, latestReleasedVersion)
+	}
+
+	return nil
+}
+
+// checkNeverModifyReleasedChart will check if the files in the pull request modify a released chart. If a file is found to modify a released chart, an error is returned.
+func (v *validation) checkNeverModifyReleasedChart(assetFilePaths map[string]string) error {
+	assetFilePathErrors := make(map[string]error)
+
+	for _, file := range v.files {
+		if _, found := assetFilePaths[*file.Filename]; !found {
+			continue
+		}
+		if file.Status != nil && (*file.Status == "added" || *file.Status == "removed") {
+			continue
+		}
+		// any status different from "added" or "removed" means the file was modified
+		assetFilePathErrors[*file.Filename] = errModifiedChart
+	}
+
+	// give the biggest amount of information possible to the user that will need to fix the pull request.
+	if len(assetFilePathErrors) > 0 {
+		return fmt.Errorf("%w: %v", errReleaseYaml, assetFilePathErrors)
+	}
+
+	return nil
+}

--- a/pkg/auto/validate_test.go
+++ b/pkg/auto/validate_test.go
@@ -1,0 +1,728 @@
+package auto
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-github/v41/github"
+	"github.com/rancher/charts-build-scripts/pkg/lifecycle"
+	"github.com/rancher/charts-build-scripts/pkg/options"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_validateReleaseYaml(t *testing.T) {
+
+	buildExpectedError := func(assetFilePathErrors map[string]error) error {
+		return fmt.Errorf("%w: %v", errReleaseYaml, assetFilePathErrors)
+	}
+
+	vr := &lifecycle.VersionRules{
+		Rules: map[string]lifecycle.Version{
+			"2.10": {Min: "105.0.0", Max: "106.0.0"},
+			"2.9":  {Min: "104.0.0", Max: "105.0.0"},
+			"2.8":  {Min: "103.0.0", Max: "104.0.0"},
+		},
+		BranchVersion: "2.9",
+		MinVersion:    104,
+		MaxVersion:    105,
+	}
+
+	type input struct {
+		releaseOpts options.ReleaseOptions
+		validation  validation
+	}
+	type expected struct {
+		err error
+	}
+	type test struct {
+		name string
+		i    input
+		ex   expected
+	}
+
+	tests := []test{
+		// #1
+		{
+			name: "Test #1 - [1 chart; 1 version] : Expected NIL",
+			i: input{
+				releaseOpts: options.ReleaseOptions{
+					"chart-1": {"104.0.0"},
+				},
+				validation: validation{
+					files: []*github.CommitFile{
+						{
+							Filename: github.String("assets/chart-1/chart-1-104.0.0.tgz"),
+							Status:   github.String("added"),
+						},
+					},
+					dep: &lifecycle.Dependencies{
+						AssetsVersionsMap: map[string][]lifecycle.Asset{},
+					},
+				},
+			},
+			ex: expected{
+				err: nil,
+			},
+		},
+
+		// #2
+		{
+			name: "Test #2 - [1 chart; 1 version; N files; minor update] : Expected NIL",
+			i: input{
+				releaseOpts: options.ReleaseOptions{
+					"chart-1": {"104.0.1"},
+				},
+				validation: validation{
+					files: []*github.CommitFile{
+						{
+							Filename: github.String("assets/chart-1/chart-1-104.0.1.tgz"),
+							Status:   github.String("added"),
+						},
+						{
+							Filename: github.String("release.yaml"),
+							Status:   github.String("modified"),
+						},
+						{
+							Filename: github.String("charts/chart-1/Chart.yaml"),
+							Status:   github.String("modified"),
+						},
+					},
+					dep: &lifecycle.Dependencies{
+						AssetsVersionsMap: map[string][]lifecycle.Asset{
+							"chart-1": []lifecycle.Asset{
+								{
+									Version: "104.0.1",
+								},
+								{
+									Version: "104.0.0",
+								},
+							},
+						},
+						VR: vr,
+					},
+				},
+			},
+			ex: expected{
+				err: nil,
+			},
+		},
+
+		// #3
+		{
+			name: "Test #3 - [2 charts; 1 version; N files; 2 new charts] : Expected NIL",
+			i: input{
+				releaseOpts: options.ReleaseOptions{
+					"chart-1": {"104.0.0"},
+					"chart-2": {"104.0.0"},
+				},
+				validation: validation{
+					files: []*github.CommitFile{
+						{
+							Filename: github.String("assets/chart-1/chart-1-104.0.0.tgz"),
+							Status:   github.String("added"),
+						},
+						{
+							Filename: github.String("assets/chart-2/chart-2-104.0.0.tgz"),
+							Status:   github.String("added"),
+						},
+						{
+							Filename: github.String("release.yaml"),
+							Status:   github.String("modified"),
+						},
+						{
+							Filename: github.String("charts/chart-1/Chart.yaml"),
+							Status:   github.String("modified"),
+						},
+					},
+					dep: &lifecycle.Dependencies{
+						AssetsVersionsMap: map[string][]lifecycle.Asset{
+							"chart-1": []lifecycle.Asset{
+								{
+									Version: "104.0.0",
+								},
+							},
+							"chart-2": []lifecycle.Asset{
+								{
+									Version: "104.0.0",
+								},
+							},
+						},
+						VR: vr,
+					},
+				},
+			},
+			ex: expected{
+				err: nil,
+			},
+		},
+
+		// #4
+		{
+			name: "Test #4 - [1 chart; 1 version; N files] : Expected ERROR",
+			i: input{
+				releaseOpts: options.ReleaseOptions{
+					"chart-1": {"104.0.0"},
+				},
+				validation: validation{
+					files: []*github.CommitFile{
+						{
+							Filename: github.String("assets/chart-1/chart-1-104.0.0.tgz"),
+							Status:   github.String("modified"),
+						},
+						{
+							Filename: github.String("release.yaml"),
+							Status:   github.String("modified"),
+						},
+						{
+							Filename: github.String("charts/chart-1/Chart.yaml"),
+							Status:   github.String("modified"),
+						},
+					},
+					dep: &lifecycle.Dependencies{
+						AssetsVersionsMap: map[string][]lifecycle.Asset{
+							"chart-1": []lifecycle.Asset{
+								{
+									Version: "104.0.0",
+								},
+							},
+						},
+						VR: vr,
+					},
+				},
+			},
+			ex: expected{
+				err: buildExpectedError(map[string]error{
+					"assets/chart-1/chart-1-104.0.0.tgz": errModifiedChart,
+				}),
+			},
+		},
+
+		// #5
+		{
+			name: "Test #5 - [2 chart; 1 version; N files] : Expected ERROR",
+			i: input{
+				releaseOpts: options.ReleaseOptions{
+					"chart-1": {"104.0.0"},
+					"chart-2": {"104.0.0"},
+				},
+				validation: validation{
+					files: []*github.CommitFile{
+						{
+							Filename: github.String("assets/chart-1/chart-1-104.0.0.tgz"),
+							Status:   github.String("added"),
+						},
+						{
+							Filename: github.String("assets/chart-2/chart-2-104.0.0.tgz"),
+							Status:   github.String("modified"),
+						},
+						{
+							Filename: github.String("release.yaml"),
+							Status:   github.String("modified"),
+						},
+						{
+							Filename: github.String("charts/chart-1/Chart.yaml"),
+							Status:   github.String("modified"),
+						},
+					},
+					dep: &lifecycle.Dependencies{
+						AssetsVersionsMap: map[string][]lifecycle.Asset{
+							"chart-1": []lifecycle.Asset{
+								{
+									Version: "104.0.0",
+								},
+							},
+							"chart-2": []lifecycle.Asset{
+								{
+									Version: "104.0.0",
+								},
+							},
+						},
+						VR: vr,
+					},
+				},
+			},
+			ex: expected{
+				err: buildExpectedError(map[string]error{
+					"assets/chart-2/chart-2-104.0.0.tgz": errModifiedChart,
+				}),
+			},
+		},
+
+		// #6
+		{
+			name: "Test #6 - [2 chart; 1 version; N files] : Expected >1 ERRORs",
+			i: input{
+				releaseOpts: options.ReleaseOptions{
+					"chart-1": {"104.0.0"},
+					"chart-2": {"104.0.0"},
+				},
+				validation: validation{
+					files: []*github.CommitFile{
+						{
+							Filename: github.String("assets/chart-1/chart-1-104.0.0.tgz"),
+							Status:   github.String("modfied"),
+						},
+						{
+							Filename: github.String("assets/chart-2/chart-2-104.0.0.tgz"),
+							Status:   github.String("modified"),
+						},
+						{
+							Filename: github.String("release.yaml"),
+							Status:   github.String("modified"),
+						},
+						{
+							Filename: github.String("charts/chart-1/Chart.yaml"),
+							Status:   github.String("modified"),
+						},
+					},
+					dep: &lifecycle.Dependencies{
+						AssetsVersionsMap: map[string][]lifecycle.Asset{
+							"chart-1": []lifecycle.Asset{
+								{
+									Version: "104.0.0",
+								},
+							},
+							"chart-2": []lifecycle.Asset{
+								{
+									Version: "104.0.0",
+								},
+							},
+						},
+						VR: vr,
+					},
+				},
+			},
+			ex: expected{
+				err: buildExpectedError(map[string]error{
+					"assets/chart-1/chart-1-104.0.0.tgz": errModifiedChart,
+					"assets/chart-2/chart-2-104.0.0.tgz": errModifiedChart,
+				}),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.i.validation.validateReleaseYaml(tt.i.releaseOpts)
+			if tt.ex.err == nil {
+				assert.Nil(t, err, "expected nil error")
+			} else {
+				assert.EqualError(t, err, tt.ex.err.Error(), "unexpected error")
+			}
+		})
+	}
+}
+
+func Test_checkMinorPatchVersion(t *testing.T) {
+	vr := &lifecycle.VersionRules{
+		Rules: map[string]lifecycle.Version{
+			"2.10": {Min: "105.0.0", Max: "106.0.0"},
+			"2.9":  {Min: "104.0.0", Max: "105.0.0"},
+			"2.8":  {Min: "103.0.0", Max: "104.0.0"},
+		},
+		BranchVersion: "2.9",
+		MinVersion:    104,
+		MaxVersion:    105,
+	}
+
+	type input struct {
+		validation            validation
+		version               string
+		latestReleasedVersion string
+	}
+	type expected struct {
+		err error
+	}
+	type test struct {
+		name string
+		i    input
+		ex   expected
+	}
+
+	tests := []test{
+		{
+			name: "Test #1 [patch update] : Expected NIL",
+			i: input{
+				validation: validation{
+					dep: &lifecycle.Dependencies{
+						VR: vr,
+					},
+				},
+				version:               "104.0.1",
+				latestReleasedVersion: "104.0.0",
+			},
+			ex: expected{
+				err: nil,
+			},
+		},
+		{
+			name: "Test #2 [minor update] : Expected NIL",
+			i: input{
+				validation: validation{
+					dep: &lifecycle.Dependencies{
+						VR: vr,
+					},
+				},
+				version:               "104.1.0",
+				latestReleasedVersion: "104.0.0",
+			},
+			ex: expected{
+				err: nil,
+			},
+		},
+		{
+			name: "Test #3 [minor/patch update] : Expected Error",
+			i: input{
+				validation: validation{
+					dep: &lifecycle.Dependencies{
+						VR: vr,
+					},
+				},
+				version:               "104.1.1",
+				latestReleasedVersion: "104.0.0",
+			},
+			ex: expected{
+				err: fmt.Errorf("%w; version: %s; latest version: %s", errMinorPatchVersion, "104.1.1", "104.0.0"),
+			},
+		},
+		{
+			name: "Test #4 [patch update > 1] : Expected Error",
+			i: input{
+				validation: validation{
+					dep: &lifecycle.Dependencies{
+						VR: vr,
+					},
+				},
+				version:               "104.0.2",
+				latestReleasedVersion: "104.0.0",
+			},
+			ex: expected{
+				err: fmt.Errorf("%w; version: %s; latest version: %s", errMinorPatchVersion, "104.0.2", "104.0.0"),
+			},
+		},
+		{
+			name: "Test #5 [minor update > 1] : Expected Error",
+			i: input{
+				validation: validation{
+					dep: &lifecycle.Dependencies{
+						VR: vr,
+					},
+				},
+				version:               "104.3.0",
+				latestReleasedVersion: "104.0.0",
+			},
+			ex: expected{
+				err: fmt.Errorf("%w; version: %s; latest version: %s", errMinorPatchVersion, "104.3.0", "104.0.0"),
+			},
+		},
+		{
+			name: "Test #6 [forward-ported chart] : Expected nil",
+			i: input{
+				validation: validation{
+					dep: &lifecycle.Dependencies{
+						VR: vr,
+					},
+				},
+				version:               "103.1.5",
+				latestReleasedVersion: "104.1.2",
+			},
+			ex: expected{
+				err: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.i.validation.checkMinorPatchVersion(tt.i.version, tt.i.latestReleasedVersion)
+			if tt.ex.err == nil {
+				assert.Nil(t, err, "expected nil error")
+			} else {
+				assert.EqualError(t, err, tt.ex.err.Error(), "unexpected error")
+			}
+		})
+	}
+}
+
+func Test_checkNeverModifyReleasedChart(t *testing.T) {
+
+	buildExpectedError := func(assetFilePathErrors map[string]error) error {
+		return fmt.Errorf("%w: %v", errReleaseYaml, assetFilePathErrors)
+	}
+
+	type input struct {
+		validation     validation
+		assetFilePaths map[string]string
+	}
+	type expected struct {
+		err error
+	}
+	type test struct {
+		name string
+		i    input
+		ex   expected
+	}
+
+	tests := []test{
+		{
+			name: "Test #1 [1 filed added] : Expected NIL",
+			i: input{
+				validation: validation{
+					files: []*github.CommitFile{
+						{
+							Filename: github.String("assets/chart-1/chart-1-104.0.0.tgz"),
+							Status:   github.String("added"),
+						},
+					},
+				},
+				assetFilePaths: map[string]string{
+					"assets/chart-1/chart-1-104.0.0.tgz": "104.0.0",
+				},
+			},
+			ex: expected{
+				err: nil,
+			},
+		},
+		{
+			name: "Test #2 [1 filed removed] : Expected NIL",
+			i: input{
+				validation: validation{
+					files: []*github.CommitFile{
+						{
+							Filename: github.String("assets/chart-1/chart-1-104.0.0.tgz"),
+							Status:   github.String("removed"),
+						},
+					},
+				},
+				assetFilePaths: map[string]string{
+					"assets/chart-1/chart-1-104.0.0.tgz": "104.0.0",
+				},
+			},
+			ex: expected{
+				err: nil,
+			},
+		},
+		{
+			name: "Test #3 [1 filed modified] : Expected Error",
+			i: input{
+				validation: validation{
+					files: []*github.CommitFile{
+						{
+							Filename: github.String("assets/chart-1/chart-1-104.0.0.tgz"),
+							Status:   github.String("modified"),
+						},
+					},
+				},
+				assetFilePaths: map[string]string{
+					"assets/chart-1/chart-1-104.0.0.tgz": "104.0.0",
+				},
+			},
+			ex: expected{
+				err: buildExpectedError(map[string]error{
+					"assets/chart-1/chart-1-104.0.0.tgz": errModifiedChart,
+				}),
+			},
+		},
+		{
+			name: "Test #4 [1 filed any wrong state] : Expected Error",
+			i: input{
+				validation: validation{
+					files: []*github.CommitFile{
+						{
+							Filename: github.String("assets/chart-1/chart-1-104.0.0.tgz"),
+							Status:   github.String("xxxxxx"),
+						},
+					},
+				},
+				assetFilePaths: map[string]string{
+					"assets/chart-1/chart-1-104.0.0.tgz": "104.0.0",
+				},
+			},
+			ex: expected{
+				err: buildExpectedError(map[string]error{
+					"assets/chart-1/chart-1-104.0.0.tgz": errModifiedChart,
+				}),
+			},
+		},
+		{
+			name: "Test #5 [1 filed added; several others modified] : Expected NIL",
+			i: input{
+				validation: validation{
+					files: []*github.CommitFile{
+						{
+							Filename: github.String("assets/chart-1/chart-1-104.0.0.tgz"),
+							Status:   github.String("added"),
+						},
+						{
+							Filename: github.String("charts/chart-1/Chart.yaml"),
+							Status:   github.String("modified"),
+						},
+						{
+							Filename: github.String("charts/chart-1/value.yaml"),
+							Status:   github.String("removed"),
+						},
+						{
+							Filename: github.String("release.yaml"),
+							Status:   github.String("modified"),
+						},
+					},
+				},
+				assetFilePaths: map[string]string{
+					"assets/chart-1/chart-1-104.0.0.tgz": "104.0.0",
+				},
+			},
+			ex: expected{
+				err: nil,
+			},
+		},
+		{
+			name: "Test #6 [Several files added/removed] : Expected Nil",
+			i: input{
+				validation: validation{
+					files: []*github.CommitFile{
+						{
+							Filename: github.String("assets/chart-1/chart-1-104.0.0.tgz"),
+							Status:   github.String("added"),
+						},
+						{
+							Filename: github.String("assets/chart-2/chart-2-104.1.0.tgz"),
+							Status:   github.String("removed"),
+						},
+						{
+							Filename: github.String("assets/chart-3/chart-2-104.2.0.tgz"),
+							Status:   github.String("added"),
+						},
+						{
+							Filename: github.String("charts/chart-1/Chart.yaml"),
+							Status:   github.String("modified"),
+						},
+						{
+							Filename: github.String("charts/chart-2/value.yaml"),
+							Status:   github.String("removed"),
+						},
+						{
+							Filename: github.String("charts/chart-2/Chart.yaml"),
+							Status:   github.String("modified"),
+						},
+						{
+							Filename: github.String("charts/chart-2/value.yaml"),
+							Status:   github.String("removed"),
+						},
+						{
+							Filename: github.String("charts/chart-3/value.yaml"),
+							Status:   github.String("removed"),
+						},
+						{
+							Filename: github.String("charts/chart-3/Chart.yaml"),
+							Status:   github.String("modified"),
+						},
+						{
+							Filename: github.String("charts/chart-3/value.yaml"),
+							Status:   github.String("removed"),
+						},
+
+						{
+							Filename: github.String("release.yaml"),
+							Status:   github.String("modified"),
+						},
+					},
+				},
+				assetFilePaths: map[string]string{
+					"assets/chart-1/chart-1-104.0.0.tgz": "104.0.0",
+					"assets/chart-2/chart-2-104.1.0.tgz": "104.1.0",
+					"assets/chart-3/chart-3-104.2.0.tgz": "104.2.0",
+				},
+			},
+			ex: expected{
+				err: nil,
+			},
+		},
+
+		{
+			name: "Test #7 [Several files added/removed and several modified] : Expected Error",
+			i: input{
+				validation: validation{
+					files: []*github.CommitFile{
+						{
+							Filename: github.String("assets/chart-1/chart-1-104.0.0.tgz"),
+							Status:   github.String("added"),
+						},
+						{
+							Filename: github.String("assets/chart-2/chart-2-104.1.0.tgz"),
+							Status:   github.String("removed"),
+						},
+						{
+							Filename: github.String("assets/chart-3/chart-3-104.2.0.tgz"),
+							Status:   github.String("added"),
+						},
+						{
+							Filename: github.String("assets/chart-4/chart-4-104.0.0.tgz"),
+							Status:   github.String("modified"),
+						},
+						{
+							Filename: github.String("assets/chart-4-crd/chart-4-crd-104.0.0.tgz"),
+							Status:   github.String("modified"),
+						},
+						{
+							Filename: github.String("charts/chart-1/Chart.yaml"),
+							Status:   github.String("modified"),
+						},
+						{
+							Filename: github.String("charts/chart-2/value.yaml"),
+							Status:   github.String("removed"),
+						},
+						{
+							Filename: github.String("charts/chart-2/Chart.yaml"),
+							Status:   github.String("modified"),
+						},
+						{
+							Filename: github.String("charts/chart-2/value.yaml"),
+							Status:   github.String("removed"),
+						},
+						{
+							Filename: github.String("charts/chart-3/value.yaml"),
+							Status:   github.String("removed"),
+						},
+						{
+							Filename: github.String("charts/chart-3/Chart.yaml"),
+							Status:   github.String("modified"),
+						},
+						{
+							Filename: github.String("charts/chart-3/value.yaml"),
+							Status:   github.String("removed"),
+						},
+
+						{
+							Filename: github.String("release.yaml"),
+							Status:   github.String("modified"),
+						},
+					},
+				},
+				assetFilePaths: map[string]string{
+					"assets/chart-1/chart-1-104.0.0.tgz":         "104.0.0",
+					"assets/chart-2/chart-1-104.1.0.tgz":         "104.1.0",
+					"assets/chart-3/chart-1-104.2.0.tgz":         "104.2.0",
+					"assets/chart-4/chart-4-104.0.0.tgz":         "104.0.0",
+					"assets/chart-4-crd/chart-4-crd-104.0.0.tgz": "104.0.0",
+				},
+			},
+			ex: expected{
+				err: buildExpectedError(map[string]error{
+					"assets/chart-4/chart-4-104.0.0.tgz":         errModifiedChart,
+					"assets/chart-4-crd/chart-4-crd-104.0.0.tgz": errModifiedChart,
+				}),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.i.validation.checkNeverModifyReleasedChart(tt.i.assetFilePaths)
+			if tt.ex.err == nil {
+				assert.Nil(t, err, "expected nil error")
+			} else {
+				assert.EqualError(t, err, tt.ex.err.Error(), "unexpected error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Issue: https://github.com/rancher/ecm-distro-tools/issues/469

This solution is only for `Checkpoint: 0`, defined in the abovementioned issue.  

### Checkpoint 0: Validate **release.yaml**

Validation steps:
- [x] Each chart version in **release.yaml** DOES NOT modify an already released chart. If so, stop and modify the versions so that it releases a net-new chart.
- [x] Each chart version in **release.yaml** IS exactly 1 more patch/minor version than the last released chart version. If not, stop and modify the versions so that it releases a net-new chart.

