### PR TITLE
Compare index.yaml for integrity of git pages. 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2
+	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v41 v41.0.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/sirupsen/logrus v1.8.1
@@ -72,7 +73,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
-	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect

--- a/go.sum
+++ b/go.sum
@@ -352,8 +352,8 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
-github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v41 v41.0.0 h1:HseJrM2JFf2vfiZJ8anY2hqBjdfY1Vlj/K27ueww4gg=
 github.com/google/go-github/v41 v41.0.0/go.mod h1:XgmCA5H323A9rtgExdTcnDkcqp6S30AVACCBDOonIxg=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=

--- a/main.go
+++ b/main.go
@@ -337,7 +337,6 @@ func main() {
 					Usage: `Usage:
 					./bin/charts-build-scripts <command> --branch="release-v2.y"
 					BRANCH="release-v2.y" make <command>
-
 					Available branches for release: (release-v2.8; release-v2.9; release-v2.10...)
 					`,
 					Required:    true,
@@ -371,6 +370,25 @@ func main() {
 				cli.BoolFlag{
 					Name:  "skip",
 					Usage: "Skip the execution and return success",
+				},
+			},
+		},
+		{
+			Name: "compare-index-files",
+			Usage: `Compare the index.yaml between github repository and charts.rancher.io.
+			`,
+			Action: compareIndexFiles,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name: "branch,b",
+					Usage: `Usage:
+					./bin/charts-build-scripts <command> --branch="release-v2.y"
+					BRANCH="release-v2.y" make <command>
+					Available branches for release: (release-v2.8; release-v2.9; release-v2.10...)
+					`,
+					Required:    true,
+					EnvVar:      defaultBranchEnvironmentVariable,
+					Destination: &Branch,
 				},
 			},
 		},
@@ -802,4 +820,19 @@ func validateRelease(c *cli.Context) {
 		fmt.Printf("failed to validate pull request: %v \n", err)
 		os.Exit(1)
 	}
+}
+
+func compareIndexFiles(c *cli.Context) {
+	if Branch == "" {
+		fmt.Println("BRANCH environment variable must be set to run validate-release-charts")
+		os.Exit(1)
+	}
+
+	rootFs := filesystem.GetFilesystem(getRepoRoot())
+
+	if err := auto.CompareIndexFiles(rootFs); err != nil {
+		fmt.Printf("failed to compare index files: %v \n", err)
+		os.Exit(1)
+	}
+	fmt.Println("index.yaml files are the same at git repository and charts.rancher.io")
 }

--- a/pkg/auto/validate.go
+++ b/pkg/auto/validate.go
@@ -1,17 +1,26 @@
 package auto
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"strconv"
 
 	"github.com/Masterminds/semver"
+	"github.com/go-git/go-billy/v5"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-github/v41/github"
+	"github.com/rancher/charts-build-scripts/pkg/helm"
 	"github.com/rancher/charts-build-scripts/pkg/lifecycle"
 	"github.com/rancher/charts-build-scripts/pkg/options"
 	"github.com/rancher/charts-build-scripts/pkg/path"
+	"github.com/rancher/charts-build-scripts/pkg/rest"
 	"golang.org/x/oauth2"
+
+	helmRepo "helm.sh/helm/v3/pkg/repo"
 )
 
 // Referred to: https://github.com/rancher/charts
@@ -168,5 +177,47 @@ func (v *validation) checkNeverModifyReleasedChart(assetFilePaths map[string]str
 		return fmt.Errorf("%w: %v", errReleaseYaml, assetFilePathErrors)
 	}
 
+	return nil
+}
+
+// CompareIndexFiles will load the current index.yaml file from the root filesystem and compare it with the index.yaml file from charts.rancher.io
+func CompareIndexFiles(rootFs billy.Filesystem) error {
+	// verify, search & open current index.yaml file
+	localIndexYaml, err := helm.OpenIndexYaml(rootFs)
+	if err != nil {
+		return err
+	}
+
+	// download index.yaml from charts.rancher.io
+	body, err := rest.Get("https://charts.rancher.io/index.yaml")
+	if err != nil {
+		return err
+	}
+
+	// save it to a temporary file
+	tempIndex, err := os.CreateTemp("", "temp-index.yaml")
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer tempIndex.Close()
+
+	_, err = io.Copy(tempIndex, bytes.NewReader(body))
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	tempIndexYaml, err := helmRepo.LoadIndexFile(tempIndex.Name())
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tempIndex.Name())
+
+	// compare both index.yaml files
+	if diff := cmp.Diff(localIndexYaml, tempIndexYaml); diff != "" {
+		fmt.Println(diff)
+		return errors.New("index.yaml files are different at git repository and charts.rancher.io")
+	}
 	return nil
 }

--- a/pkg/auto/validate.go
+++ b/pkg/auto/validate.go
@@ -197,15 +197,13 @@ func CompareIndexFiles(rootFs billy.Filesystem) error {
 	// save it to a temporary file
 	tempIndex, err := os.CreateTemp("", "temp-index.yaml")
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 	defer tempIndex.Close()
 
 	_, err = io.Copy(tempIndex, bytes.NewReader(body))
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 
 	tempIndexYaml, err := helmRepo.LoadIndexFile(tempIndex.Name())

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -1,6 +1,7 @@
 package helm
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -106,4 +107,19 @@ func UpdateIndex(original, new *helmRepo.IndexFile) (*helmRepo.IndexFile, bool) 
 	// Sort and return entries
 	updatedIndex.SortEntries()
 	return updatedIndex, upToDate
+}
+
+// OpenIndexYaml will check and open the index.yaml file in the local repository at the default file path
+func OpenIndexYaml(rootFs billy.Filesystem) (*helmRepo.IndexFile, error) {
+	helmIndexFilePath := filesystem.GetAbsPath(rootFs, path.RepositoryHelmIndexFile)
+
+	exists, err := filesystem.PathExists(rootFs, path.RepositoryHelmIndexFile)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.New("index.yaml file does not exist in the local repository")
+	}
+
+	return helmRepo.LoadIndexFile(helmIndexFilePath)
 }

--- a/pkg/rest/request.go
+++ b/pkg/rest/request.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 )
@@ -50,19 +49,4 @@ func Post(url string, body, responseModel any) error {
 	}
 
 	return nil
-}
-
-// Get sends a GET request to the given URL and returns the response body as a byte slice.
-func Get(url string) ([]byte, error) {
-	resp, err := http.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status code %d", resp.StatusCode)
-	}
-
-	return io.ReadAll(resp.Body)
 }

--- a/pkg/rest/request.go
+++ b/pkg/rest/request.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
@@ -49,4 +50,19 @@ func Post(url string, body, responseModel any) error {
 	}
 
 	return nil
+}
+
+// Get sends a GET request to the given URL and returns the response body as a byte slice.
+func Get(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status code %d", resp.StatusCode)
+	}
+
+	return io.ReadAll(resp.Body)
 }


### PR DESCRIPTION
Issue: https://github.com/rancher/ecm-distro-tools/issues/475

## Solution
We are implementing a command to load the current `index.yaml` from the charts repository, download the index.yaml from `charts.rancher.io`, and compare both. 

This will be used on every release Pull Request at: [charts-repo](https://github.com/rancher/charts)
Only on the last active branch.