### PR TITLE
Slsa charts bypass

### DIFF
--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -6,41 +6,54 @@ const (
 
 	// RepositoryHelmIndexFile is the file on your Staging/Live branch that contains your Helm repository index
 	RepositoryHelmIndexFile = "index.yaml"
+
 	// RepositoryPackagesDir is a directory on your Staging branch that contains the files necessary to generate your package
 	RepositoryPackagesDir = "packages"
+
 	// RepositoryAssetsDir is a directory on your Staging/Live branch that contains chart archives for each version of your package
 	RepositoryAssetsDir = "assets"
+
 	// RepositoryChartsDir is a directory on your Staging/Live branch that contains unarchived charts for each version of your package
 	RepositoryChartsDir = "charts"
 
 	// PackageOptionsFile is the name of a file that contains information about how to prepare your package
 	// The expected structure of this file is one that can be marshalled into a PackageOptions struct
 	PackageOptionsFile = "package.yaml"
+
 	// PackageTemplatesDir is a directory containing templates used as additional chart options
 	PackageTemplatesDir = "templates"
 
 	// GeneratedChangesDir is a directory that contains GeneratedChanges
 	GeneratedChangesDir = "generated-changes"
+
 	// GeneratedChangesAdditionalChartDir is a directory that contains additionalCharts
 	GeneratedChangesAdditionalChartDir = "additional-charts"
+
 	// GeneratedChangesDependenciesDir is a directory that contains dependencies within GeneratedChangesDir
 	GeneratedChangesDependenciesDir = "dependencies"
+
 	// GeneratedChangesExcludeDir is a directory that contains excludes within GeneratedChangesDir
 	GeneratedChangesExcludeDir = "exclude"
+
 	// GeneratedChangesOverlayDir is a directory that contains overlays within GeneratedChangesDir
 	GeneratedChangesOverlayDir = "overlay"
+
 	// GeneratedChangesPatchDir is a directory that contains patches within GeneratedChangesDir
 	GeneratedChangesPatchDir = "patch"
+
 	// DependencyOptionsFile is a file that contains information about how to prepare your dependency
 	// The expected structure of this file is one that can be marshalled into a ChartOptions struct
 	DependencyOptionsFile = "dependency.yaml"
 
 	// ChartCRDDir represents the directory that we expect to contain CRDs within the chart
 	ChartCRDDir = "crds"
+
 	// ChartExtraFileDir represents the directory that contains non-YAML files
 	ChartExtraFileDir = "files"
+
 	// ChartCRDTgzFilename represents the filename of the crd's tgz file
 	ChartCRDTgzFilename = "crd-manifest.tgz"
+
 	// ChartValidateInstallCRDFile is the path to the file pushed to upstream that validates the existence of CRDs in the chart
 	ChartValidateInstallCRDFile = "templates/validate-install-crd.yaml"
 
@@ -50,7 +63,7 @@ const (
 	// RepositoryLogosDir is a directory on your Staging/Live branch that contains the files with the logos of each chart
 	RepositoryLogosDir = "assets/logos"
 
-	// RepositoryStAte file is a file to hold the current status of the released and developed assets versions
+	// RepositoryStateFile file is a file to hold the current status of the released and developed assets versions
 	RepositoryStateFile = "state.json"
 
 	// RepositoryReleaseYaml is the file on your Staging/Live branch that contains the release information

--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -63,7 +63,7 @@ const (
 	// RepositoryLogosDir is a directory on your Staging/Live branch that contains the files with the logos of each chart
 	RepositoryLogosDir = "assets/logos"
 
-	// RepositoryStateFile file is a file to hold the current status of the released and developed assets versions
+	// RepositoryStateFile is a file to hold the current status of the released and developed assets versions
 	RepositoryStateFile = "state.json"
 
 	// RepositoryReleaseYaml is the file on your Staging/Live branch that contains the release information

--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -71,4 +71,7 @@ const (
 
 	// VersionRulesFile is the file that contains the version rules for the current branch on charts-build-scripts
 	VersionRulesFile = "version_rules.json"
+
+	// SlsaYamlFile is the file that contains the list of images already synced and signed for SLSA.
+	SlsaYamlFile = "slsa.yaml"
 )

--- a/pkg/regsync/generateconfig.go
+++ b/pkg/regsync/generateconfig.go
@@ -247,7 +247,7 @@ func readSlsaYaml() ([]string, error) {
 
 	file, err := os.Open(path.SlsaYamlFile)
 	if err != nil {
-		return nil, nil // backward version compatibility
+		return nil, err // backward version compatibility
 	}
 	defer file.Close()
 

--- a/pkg/regsync/generateconfig.go
+++ b/pkg/regsync/generateconfig.go
@@ -26,18 +26,17 @@ var chartsToIgnoreTags = map[string]string{
 func GenerateConfigFile() error {
 	imageTagMap := make(map[string][]string)
 
-	err := walkAssetsFolder(imageTagMap)
-	if err != nil {
+	if err := walkAssetsFolder(imageTagMap); err != nil {
+		return err
+	}
+
+	// Remove the images that are already signed from the imageTagMap
+	if err := removeSlsaImages(imageTagMap, readSlsaYaml); err != nil {
 		return err
 	}
 
 	// Create the regsync config file
-	err = createRegSyncConfigFile(imageTagMap)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return createRegSyncConfigFile(imageTagMap)
 }
 
 // walkAssetsFolder walks over the assets folder, untars files, stores the values.yaml content

--- a/pkg/regsync/generateconfig_test.go
+++ b/pkg/regsync/generateconfig_test.go
@@ -1,0 +1,118 @@
+package regsync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_SlsaYaml(t *testing.T) {
+
+	type input struct {
+		imageTagMap      map[string][]string
+		readSlsaYamlMock func() ([]string, error)
+	}
+
+	type expected struct {
+		err         error
+		imageTagMap map[string][]string
+	}
+
+	type test struct {
+		name     string
+		input    input
+		expected expected
+	}
+
+	tests := []test{
+		{
+			name: "#1",
+			input: input{
+				imageTagMap: map[string][]string{
+					"image1": {"tag1"},
+					"image2": {"tag2"},
+					"image3": {"tag3"},
+				},
+				readSlsaYamlMock: func() ([]string, error) {
+					return []string{"image1"}, nil
+				},
+			},
+			expected: expected{
+				err: nil,
+				imageTagMap: map[string][]string{
+					"image2": {"tag2"},
+					"image3": {"tag3"},
+				},
+			},
+		},
+		{
+			name: "#2",
+			input: input{
+				imageTagMap: map[string][]string{
+					"image1": {"tag1", "tag2"},
+					"image2": {"tag2"},
+					"image3": {"tag3", "tag4"},
+				},
+				readSlsaYamlMock: func() ([]string, error) {
+					return []string{"image1", "image2"}, nil
+				},
+			},
+			expected: expected{
+				err: nil,
+				imageTagMap: map[string][]string{
+					"image3": {"tag3", "tag4"},
+				},
+			},
+		},
+		{
+			name: "#3",
+			input: input{
+				imageTagMap: map[string][]string{
+					"image1": {"tag1", "tag2"},
+				},
+				readSlsaYamlMock: func() ([]string, error) {
+					return []string{"image1", "image2"}, nil
+				},
+			},
+			expected: expected{
+				err:         nil,
+				imageTagMap: map[string][]string{},
+			},
+		},
+		{
+			name: "#4",
+			input: input{
+				imageTagMap: map[string][]string{},
+				readSlsaYamlMock: func() ([]string, error) {
+					return []string{"image1", "image2"}, nil
+				},
+			},
+			expected: expected{
+				err:         nil,
+				imageTagMap: map[string][]string{},
+			},
+		},
+		{
+			name: "#5",
+			input: input{
+				imageTagMap: map[string][]string{},
+				readSlsaYamlMock: func() ([]string, error) {
+					return []string{}, nil
+				},
+			},
+			expected: expected{
+				err:         nil,
+				imageTagMap: map[string][]string{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := removeSlsaImages(tt.input.imageTagMap, tt.input.readSlsaYamlMock)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected.imageTagMap, tt.input.imageTagMap)
+
+		})
+	}
+}


### PR DESCRIPTION
Long story short:

Charts that have images supporting SLSA must no longer be synced from:

docker hub -> primer registry. 

### Solution

On the charts repository, there will be a new file called `slsa.yaml`; see: https://github.com/rancher/charts/pull/4760

The chart owners will update this file with the new slsa compliant images. 
We bypass the `regsync process` for the prime registry for all these images.


