### PR TITLE
adding ssh upstream remote option for release update cmd

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -258,6 +258,9 @@ func (g *Git) DeleteBranch(branch string) error {
 // CheckFileExists checks if a file exists in the git repository for a specific branch
 func (g *Git) CheckFileExists(file, branch string) error {
 	upstreamRemote := g.Remotes["https://github.com/rancher/charts"]
+	if upstreamRemote == "" {
+		upstreamRemote = g.Remotes["git@github.com:rancher/charts.git"]
+	}
 	target := upstreamRemote + "/" + branch + ":" + file
 	return exec.Command("git", "-C", g.Dir, "cat-file", "-e", target).Run()
 }


### PR DESCRIPTION
Quickly resolving the following bug before the release happens:

```
release update charts 2.10 rancher-vsphere-csi 105.0.1+up3.3.1-rancher7
error:  exit status 1: time="2025-01-22T12:17:48-03:00" level=fatal msg="failed to execute release: asset version not found in dev branch: exit status 128"

git remote -v 
nicholasSUSE	git@github.com:nicholasSUSE/charts.git (fetch)
nicholasSUSE	git@github.com:nicholasSUSE/charts.git (push)
upstream	git@github.com:rancher/charts.git (fetch)
upstream	git@github.com:rancher/charts.git (push)
```
