### PR TITLE
Add a "soft-errors" mode for prepare subcommand

### DIFF
--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -1,0 +1,20 @@
+package util
+
+// SoftErrorMode allows for skipping certain non-fatal errors from breaking execution
+type SoftErrorMode struct {
+	Enabled bool
+}
+
+var _softErrorMode *SoftErrorMode
+
+func InitSoftErrorMode() {
+	_softErrorMode = &SoftErrorMode{false}
+}
+
+func SetSoftErrorMode(newValue bool) {
+	_softErrorMode.Enabled = newValue
+}
+
+func IsSoftErrorOn() bool {
+	return _softErrorMode.Enabled
+}


### PR DESCRIPTION
This is useful in certain rebase actions teams with complicated charts may face. Essentially this flag will allow for all existing patches to be applied when preparing even if they would cause errors. This way someone doing a rebase can see all the conflicting patches in one execution.

They can either try to fix as many as possible, or opt to temporarily disable them and recreate them.