### PR TITLE
removing auto-bump during validation

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/rancher/charts-build-scripts/pkg/util"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/rancher/charts-build-scripts/pkg/util"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/rancher/charts-build-scripts/pkg/auto"
@@ -478,21 +479,6 @@ func generateCharts(c *cli.Context) {
 		if p.Auto == false {
 			if err := p.GenerateCharts(chartsScriptOptions.OmitBuildMetadataOnExport); err != nil {
 				logrus.Fatal(err)
-			}
-		} else {
-			repoRoot := getRepoRoot()
-
-			bump, err := auto.SetupBump(repoRoot, p.Name, "dev-v2.10", chartsScriptOptions)
-			if err != nil {
-				fmt.Printf("failed to initialize the chart bump: %s", err.Error())
-				bump.Pkg.Clean()
-				os.Exit(1)
-			}
-
-			if err := bump.BumpChart(); err != nil {
-				fmt.Printf("failed to bump the chart: %s", err.Error())
-				bump.Pkg.Clean()
-				os.Exit(1)
 			}
 		}
 	}


### PR DESCRIPTION
Fixing issue. 

`make validate` at a specific step prepares and generates the chart from scratch. 

This does not make sense for `auto chart-bumps` because it is in a controlled environment. 

The problem arises when `make validate` is run while a new chart version is available on the upstream repository but not merged yet. 

This will break the CI, although it should not. 

See failing job for webhook that triggered the bug on rancher-cis-benchmark: https://github.com/rancher/charts/actions/runs/13166230305/job/36748475714?pr=5098