### PR TITLE
feat(dev) : specify root repo path using DEV_REPO_ROOT for debugging

### DIFF
--- a/main.go
+++ b/main.go
@@ -644,7 +644,7 @@ func cleanCache(c *cli.Context) {
 }
 
 func parseScriptOptions() *options.ChartsScriptOptions {
-	configYaml, err := ioutil.ReadFile(defaultChartsScriptOptionsFile)
+	configYaml, err := ioutil.ReadFile(ChartsScriptOptionsFile)
 	if err != nil {
 		logrus.Fatalf("Unable to find configuration file: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -644,7 +643,7 @@ func cleanCache(c *cli.Context) {
 }
 
 func parseScriptOptions() *options.ChartsScriptOptions {
-	configYaml, err := ioutil.ReadFile(ChartsScriptOptionsFile)
+	configYaml, err := os.ReadFile(ChartsScriptOptionsFile)
 	if err != nil {
 		logrus.Fatalf("Unable to find configuration file: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -634,7 +634,7 @@ func createOrUpdateTemplate(c *cli.Context) {
 }
 
 func setupCache(c *cli.Context) error {
-	return puller.InitRootCache(CacheMode, path.DefaultCachePath)
+	return puller.InitRootCache(getRepoRoot(), CacheMode, path.DefaultCachePath)
 }
 
 func cleanCache(c *cli.Context) {
@@ -656,6 +656,13 @@ func parseScriptOptions() *options.ChartsScriptOptions {
 }
 
 func getRepoRoot() string {
+	var repoRoot string
+	repoRoot = os.Getenv("DEV_REPO_ROOT")
+	if repoRoot != "" {
+		logrus.Debugf("Using repo root : %s", repoRoot)
+		return repoRoot
+	}
+
 	repoRoot, err := os.Getwd()
 	if err != nil {
 		logrus.Fatalf("Unable to get current working directory: %s", err)
@@ -697,11 +704,12 @@ func checkImages(c *cli.Context) {
 }
 
 func checkRCTagsAndVersions(c *cli.Context) {
+	repoRoot := getRepoRoot()
 	// Grab all images that contain RC tags
-	rcImageTagMap := images.CheckRCTags()
+	rcImageTagMap := images.CheckRCTags(repoRoot)
 
 	// Grab all chart versions that contain RC tags
-	rcChartVersionMap := charts.CheckRCCharts()
+	rcChartVersionMap := charts.CheckRCCharts(repoRoot)
 
 	// If there are any charts that contains RC version or images that contains RC tags
 	// log them and return an error

--- a/pkg/auto/chart_bump.go
+++ b/pkg/auto/chart_bump.go
@@ -77,7 +77,7 @@ func SetupBump(repoRoot, targetPackage, targetBranch string, chScriptOpts *optio
 	}
 
 	//Initialize the lifecycle dependencies because of the versioning rules and the index.yaml mapping.
-	dependencies, err := lifecycle.InitDependencies(filesystem.GetFilesystem(repoRoot), branch, bump.targetChart)
+	dependencies, err := lifecycle.InitDependencies(repoRoot, filesystem.GetFilesystem(repoRoot), branch, bump.targetChart)
 	if err != nil {
 		err = fmt.Errorf("failure at SetupBump: %w ", err)
 		return bump, err

--- a/pkg/charts/checkRCCharts.go
+++ b/pkg/charts/checkRCCharts.go
@@ -1,7 +1,6 @@
 package charts
 
 import (
-	"os"
 	"strings"
 
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
@@ -10,14 +9,7 @@ import (
 )
 
 // CheckRCCharts checks for any charts that have RC versions
-func CheckRCCharts() map[string][]string {
-
-	// Get the current working directory
-	repoRoot, err := os.Getwd()
-	if err != nil {
-		logrus.Fatalf("Unable to get current working directory: %s", err)
-	}
-
+func CheckRCCharts(repoRoot string) map[string][]string {
 	// Get the filesystem on the repo root
 	repoFs := filesystem.GetFilesystem(repoRoot)
 

--- a/pkg/charts/crdchart.go
+++ b/pkg/charts/crdchart.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -77,7 +76,7 @@ func AddCRDValidationToChart(fs billy.Filesystem, helmChartPathWithoutCRDs, helm
 			return nil
 		}
 		absPath := filesystem.GetAbsPath(fs, path)
-		yamlFile, err := ioutil.ReadFile(absPath)
+		yamlFile, err := os.ReadFile(absPath)
 		if err != nil {
 			return fmt.Errorf("unable to read file %s: %s", absPath, err)
 		}
@@ -133,7 +132,7 @@ func AddCRDValidationToChart(fs billy.Filesystem, helmChartPathWithoutCRDs, helm
 	validateInstallCRDsContents := fmt.Sprintf(ValidateInstallCRDContentsFmt, strings.Join(formattedCRDs, "\n"))
 	validateInstallCRDsDestpath := filepath.Join(helmChartPathWithoutCRDs, path.ChartValidateInstallCRDFile)
 	// Write to file
-	err = ioutil.WriteFile(filesystem.GetAbsPath(fs, validateInstallCRDsDestpath), []byte(validateInstallCRDsContents), os.ModePerm)
+	err = os.WriteFile(filesystem.GetAbsPath(fs, validateInstallCRDsDestpath), []byte(validateInstallCRDsContents), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("encountered error while writing into %s: %s", validateInstallCRDsDestpath, err)
 	}

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -6,14 +6,14 @@ import (
 	"compress/gzip"
 	"crypto/sha1"
 	"fmt"
-	"github.com/rancher/charts-build-scripts/pkg/util"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/rancher/charts-build-scripts/pkg/util"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/osfs"
@@ -591,11 +591,11 @@ func CopyDir(fs billy.Filesystem, srcDir string, dstDir string) error {
 		if isDir {
 			return fs.MkdirAll(dstPath, os.ModePerm)
 		}
-		data, err := ioutil.ReadFile(GetAbsPath(fs, srcPath))
+		data, err := os.ReadFile(GetAbsPath(fs, srcPath))
 		if err != nil {
 			return err
 		}
-		return ioutil.WriteFile(GetAbsPath(fs, dstPath), data, os.ModePerm)
+		return os.WriteFile(GetAbsPath(fs, dstPath), data, os.ModePerm)
 	})
 }
 
@@ -608,7 +608,7 @@ func MakeSubdirectoryRoot(fs billy.Filesystem, path, subdirectory string) error 
 	if !exists {
 		return fmt.Errorf("subdirectory %s does not exist in path %s in filesystem %s", subdirectory, path, fs.Root())
 	}
-	absTempDir, err := ioutil.TempDir(fs.Root(), "make-subdirectory-root")
+	absTempDir, err := os.MkdirTemp(fs.Root(), "make-subdirectory-root")
 	if err != nil {
 		return err
 	}

--- a/pkg/images/checkRCTags.go
+++ b/pkg/images/checkRCTags.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"os"
 	"strings"
 
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
@@ -11,10 +10,10 @@ import (
 )
 
 // CheckRCTags checks for any images that have RC tags
-func CheckRCTags() map[string][]string {
+func CheckRCTags(repoRoot string) map[string][]string {
 
 	// Get the release options from the release.yaml file
-	releaseOptions := getReleaseOptions()
+	releaseOptions := getReleaseOptions(repoRoot)
 
 	logrus.Infof("Checking for RC tags in charts: %v", releaseOptions)
 
@@ -41,13 +40,7 @@ func CheckRCTags() map[string][]string {
 }
 
 // getReleaseOptions returns the release options from the release.yaml file
-func getReleaseOptions() options.ReleaseOptions {
-	// Get the current working directory
-	repoRoot, err := os.Getwd()
-	if err != nil {
-		logrus.Fatalf("Unable to get current working directory: %s", err)
-	}
-
+func getReleaseOptions(repoRoot string) options.ReleaseOptions {
 	// Get the filesystem on the repo root
 	repoFs := filesystem.GetFilesystem(repoRoot)
 

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -2,7 +2,6 @@ package lifecycle
 
 import (
 	"errors"
-	"os"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
@@ -37,13 +36,10 @@ type WalkDirFunc func(fs billy.Filesystem, dirPath string, doFunc filesystem.Rel
 // InitDependencies will check the filesystem, branch version,
 // git status, initialize the Dependencies struct and populate it.
 // If anything fails the operation will be aborted.
-func InitDependencies(rootFs billy.Filesystem, branchVersion string, currentChart string) (*Dependencies, error) {
+func InitDependencies(repoRoot string, rootFs billy.Filesystem, branchVersion string, currentChart string) (*Dependencies, error) {
 	var err error
 
-	workDir, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
+	workDir := repoRoot
 
 	git, err := git.OpenGitRepo(workDir)
 	if err != nil {

--- a/pkg/options/package.go
+++ b/pkg/options/package.go
@@ -2,7 +2,6 @@ package options
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/go-git/go-billy/v5"
@@ -105,7 +104,7 @@ func LoadPackageOptionsFromFile(fs billy.Filesystem, path string) (PackageOption
 	if !exists {
 		return packageOptions, fmt.Errorf("unable to load package options from file %s since it does not exist", filesystem.GetAbsPath(fs, path))
 	}
-	chartOptionsBytes, err := ioutil.ReadFile(filesystem.GetAbsPath(fs, path))
+	chartOptionsBytes, err := os.ReadFile(filesystem.GetAbsPath(fs, path))
 	if err != nil {
 		return packageOptions, err
 	}
@@ -146,7 +145,7 @@ func LoadChartOptionsFromFile(fs billy.Filesystem, path string) (ChartOptions, e
 	if !exists {
 		return chartOptions, fmt.Errorf("unable to load chart options from file %s since it does not exist", filesystem.GetAbsPath(fs, path))
 	}
-	chartOptionsBytes, err := ioutil.ReadFile(filesystem.GetAbsPath(fs, path))
+	chartOptionsBytes, err := os.ReadFile(filesystem.GetAbsPath(fs, path))
 	if err != nil {
 		return chartOptions, err
 	}

--- a/pkg/options/validate.go
+++ b/pkg/options/validate.go
@@ -1,7 +1,6 @@
 package options
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/hashicorp/go-version"
@@ -78,7 +77,7 @@ func LoadReleaseOptionsFromFile(fs billy.Filesystem, path string) (ReleaseOption
 		// If release.yaml does not exist, return an empty ReleaseOptions
 		return releaseOptions, nil
 	}
-	releaseOptionsBytes, err := ioutil.ReadFile(filesystem.GetAbsPath(fs, path))
+	releaseOptionsBytes, err := os.ReadFile(filesystem.GetAbsPath(fs, path))
 	if err != nil {
 		return releaseOptions, err
 	}

--- a/pkg/puller/cache.go
+++ b/pkg/puller/cache.go
@@ -37,12 +37,7 @@ func InitRootCache(repoRoot string, cacheMode bool, path string) error {
 }
 
 // CleanRootCache removes any existing entries in the cache
-func CleanRootCache(path string) error {
-	// Get repository filesystem
-	repoRoot, err := os.Getwd()
-	if err != nil {
-		logrus.Fatalf("Unable to get current working directory: %s", err)
-	}
+func CleanRootCache(repoRoot string, path string) error {
 	rootFs := filesystem.GetFilesystem(repoRoot)
 	if err := filesystem.RemoveAll(rootFs, path); err != nil {
 		return err

--- a/pkg/puller/cache.go
+++ b/pkg/puller/cache.go
@@ -13,16 +13,12 @@ import (
 var RootCache cacher = &noopCache{}
 
 // InitRootCache initializes a cache at the repository's root to be used, if it does not currently exist
-func InitRootCache(cacheMode bool, path string) error {
+func InitRootCache(repoRoot string, cacheMode bool, path string) error {
 	if !cacheMode {
 		return nil
 	}
 	logrus.Infof("Setting up cache at %s", path)
 	// Get repository filesystem
-	repoRoot, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("unable to get current working directory: %s", err)
-	}
 	rootFs := filesystem.GetFilesystem(repoRoot)
 
 	// Instantiate cache

--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -118,7 +117,7 @@ func CreateInitialCommit(repo *git.Repository) error {
 	if err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(path.Join(repoPath, "README.md"), []byte{}, 0644); err != nil {
+	if err = os.WriteFile(path.Join(repoPath, "README.md"), []byte{}, 0644); err != nil {
 		return err
 	}
 	return CommitAll(repo, "Create initial commit")

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -62,7 +62,7 @@ func (r CompareGeneratedAssetsResponse) DumpReleaseYaml(repoFs billy.Filesystem)
 
 // CompareGeneratedAssets checks to see if current assets and charts match upstream, aside from those indicated in the release.yaml
 // It returns a boolean indicating if the comparison has passed or an error
-func CompareGeneratedAssets(repoFs billy.Filesystem, u options.UpstreamOptions, branch string, releaseOptions options.ReleaseOptions) (CompareGeneratedAssetsResponse, error) {
+func CompareGeneratedAssets(repoRoot string, repoFs billy.Filesystem, u options.UpstreamOptions, branch string, releaseOptions options.ReleaseOptions) (CompareGeneratedAssetsResponse, error) {
 	response := CompareGeneratedAssetsResponse{
 		UntrackedInRelease:  options.ReleaseOptions{},
 		ModifiedPostRelease: options.ReleaseOptions{},
@@ -70,7 +70,7 @@ func CompareGeneratedAssets(repoFs billy.Filesystem, u options.UpstreamOptions, 
 	}
 
 	// Initialize lifecycle package for validating with assets lifecycle rules
-	lifeCycleDep, err := lifecycle.InitDependencies(repoFs, lifecycle.ExtractBranchVersion(branch), "")
+	lifeCycleDep, err := lifecycle.InitDependencies(repoRoot, repoFs, lifecycle.ExtractBranchVersion(branch), "")
 	if err != nil {
 		logrus.Fatalf("encountered error while initializing lifecycle dependencies: %s", err)
 	}


### PR DESCRIPTION
- Allows specifying relative/absolute root repo paths for debugging by developers

- correctly pass in configuration.yaml path config flag : places where `defaultChartsScriptOptionsFile` were used should've been using `ChartsScriptOptionsFile` instead
```go
configFlag := cli.StringFlag{
		Name:        "config",
		Usage:       "A configuration file with additional options for allowing this branch to interact with other branches",
		TakesFile:   true,
		Destination: &ChartsScriptOptionsFile,
		Value:       defaultChartsScriptOptionsFile,
	}
```

- Migrated references of deprecated ioutil package to stable:
  - `ioutil.ReadFile` -> `os.Readfile`
  - `ioutil.WriteFile` -> `os.WriteFile`
  - `ioutil.MkdirTemp` -> `os.Mkdirtemp`