### PR TITLE
(fix?) do not create a copy of helm index using index.Merge()

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -56,20 +56,22 @@ func CreateOrUpdateHelmIndex(rootFs billy.Filesystem) error {
 }
 
 // UpdateIndex updates the original index with the new contents
-func UpdateIndex(original, new *helmRepo.IndexFile) (*helmRepo.IndexFile, bool) {
+// !! modifies newRepo in place and returns it
+func UpdateIndex(origRepo, newRepo *helmRepo.IndexFile) (*helmRepo.IndexFile, bool) {
 	// Create a copy of new to return
-	updatedIndex := helmRepo.NewIndexFile()
-	updatedIndex.Merge(new)
+	// !! This is not equivalent to creating a copy of the index file !!
+	// updatedIndex := helmRepo.NewIndexFile()
+	// updatedIndex.Merge(newRepo)
 	upToDate := true
 
 	// Preserve generated timestamp
-	updatedIndex.Generated = original.Generated
+	newRepo.Generated = origRepo.Generated
 
 	// Ensure newer version of chart is used if it has been updated
-	for chartName, chartVersions := range updatedIndex.Entries {
+	for chartName, chartVersions := range newRepo.Entries {
 		for i, chartVersion := range chartVersions {
 			version := chartVersion.Version
-			if !original.Has(chartName, version) {
+			if !origRepo.Has(chartName, version) {
 				// Keep the newly generated chart version as-is
 				upToDate = false
 				logrus.Debugf("Chart %s has introduced a new version %s: %v", chartName, chartVersion.Version, *chartVersion)
@@ -77,7 +79,7 @@ func UpdateIndex(original, new *helmRepo.IndexFile) (*helmRepo.IndexFile, bool) 
 			}
 			// Get original chart version
 			var originalChartVersion *helmRepo.ChartVersion
-			for _, originalChartVersion = range original.Entries[chartName] {
+			for _, originalChartVersion = range origRepo.Entries[chartName] {
 				if originalChartVersion.Version == chartVersion.Version {
 					// found originalChartVersion, which must exist since we checked that the original has it
 					break
@@ -86,7 +88,7 @@ func UpdateIndex(original, new *helmRepo.IndexFile) (*helmRepo.IndexFile, bool) 
 			// Try to preserve it only if nothing has changed.
 			if originalChartVersion.Digest == chartVersion.Digest {
 				// Don't modify created timestamp
-				updatedIndex.Entries[chartName][i].Created = originalChartVersion.Created
+				newRepo.Entries[chartName][i].Created = originalChartVersion.Created
 			} else {
 				upToDate = false
 				logrus.Debugf("Chart %s at version %s has been modified", chartName, originalChartVersion.Version)
@@ -94,9 +96,9 @@ func UpdateIndex(original, new *helmRepo.IndexFile) (*helmRepo.IndexFile, bool) 
 		}
 	}
 
-	for chartName, chartVersions := range original.Entries {
+	for chartName, chartVersions := range origRepo.Entries {
 		for _, chartVersion := range chartVersions {
-			if !updatedIndex.Has(chartName, chartVersion.Version) {
+			if !newRepo.Has(chartName, chartVersion.Version) {
 				// Chart was removed
 				upToDate = false
 				logrus.Debugf("Chart %s at version %s has been removed: %v", chartName, chartVersion.Version, *chartVersion)
@@ -106,8 +108,8 @@ func UpdateIndex(original, new *helmRepo.IndexFile) (*helmRepo.IndexFile, bool) 
 	}
 
 	// Sort and return entries
-	updatedIndex.SortEntries()
-	return updatedIndex, upToDate
+	newRepo.SortEntries()
+	return newRepo, upToDate
 }
 
 // OpenIndexYaml will check and open the index.yaml file in the local repository at the default file path


### PR DESCRIPTION
Fixes https://github.com/rancher/charts-build-scripts/issues/100

Why doesn't the current iteration support multiple upstream chart rcs? 

Let's use these to example versions:
- `106.0.0+up5.0.0-rc.1`
- `106.0.0+up5.0.0-rc.2`

Semantically for rancher these would indicate that we want to release a chart for the 2.11 line, with the chart patches being the same (i.e.) 106.0.0, but with different upstream charts, which technically makes them **different** charts.

However using semver, these are actually treated as the same version, but with different build metadata :  `up5.0.0-rc.1` versus : `up5.0.0-rc.2`

---


When we generate the new index file from `assets` path :
```go
// Generate the current index file from the assets/ directory
	newHelmIndexFile, err := helmRepo.IndexDirectory(absRepositoryAssetsDir, path.RepositoryAssetsDir)
	if err != nil {
		return fmt.Errorf("encountered error while trying to generate new Helm index: %s", err)
	}
```
we do correctly pickup both  `106.0.0+up5.0.0-rc.1` `106.0.0+up5.0.0-rc.2`

so what happens next? When it comes time to update the index, we call :

```go
// Update index
	helmIndexFile, upToDate := UpdateIndex(helmIndexFile, newHelmIndexFile)
```

which in turn calls (which is equivalent to the upstream helm command `helm index merge ...`):
```go
	updatedIndex := helmRepo.NewIndexFile()
	updatedIndex.Merge(newRepo)
```

to use as the new index. BUT as we iterate and merge into the empty index, we check that there are no equivalent semver versions. So what ends up happening is `106.0.0+up5.0.0-rc.1` gets add to the update index but `106.0.0+up5.0.0-rc.2` correctly does not get added to the update index because both `106.0.0+up5.0.0-rc.1`,`106.0.0+up5.0.0-rc.2` are semantically equivalent (as expected):
```go
package main

import (
	"fmt"

	"github.com/Masterminds/semver/v3"
)

func main() {
	constraint, err := semver.NewConstraint("106.0.0+up5.0.0-rc.1")
	if err != nil {
		panic(err)
	}
	fmt.Println(constraint.Check(semver.MustParse("106.0.0+up5.0.0-rc.2")))
}

```
>> true

--

I guess the question becomes should we even allow `106.0.0+up5.0.0-rc.1`,`106.0.0+up5.0.0-rc.2` to be released at the same time? 

If we don't it makes it impossible to release two charts with the same base version like `106.0.0`, which could be relevant for charts like `rancher-monitoring` and `prometheus-federator` where we may want to release two upstream versions using the same set of patches.

In the existing codebase, we can work around that problem like:
```
106.0.0+up5.0.0
106.0.1+up5.1.0
```

but we can get into weird versioning scenarios where if we want to update the set of patches to particular upstream charts
```
106.0.0+up5.0.0
106.0.1+up5.1.0
106.0.2+up5.0.0
106.0.3+up5.1.0
```
which I'm not against at all, but we should document. That way of doing things also becomes VERY time consuming and can be confusing as multiple set of patches from different people come in.

---

If this is determined a won't-fix as it likely should, I'd at least like to add some validation logic to check that all entries in `assets` path are actually in `index.yaml` to make PRs that do updates like `106.0.0+up5.0.0-rc.1`->`106.0.0+up5.0.0-rc.2` don't accidentally end up with a missing index.yaml entry if we don't remove `106.0.0+up5.0.0-rc.1`
