### PR TITLE
Fix make validate .orig files

### DIFF
--- a/main.go
+++ b/main.go
@@ -562,10 +562,10 @@ func validateRepo(c *cli.Context) {
 
 		logrus.Infof("Checking if Git is clean after generating charts")
 		_, _, status = getGitInfo()
-		if !status.IsClean() {
-			logrus.Warnf("Generated charts produced the following changes in Git.\n%s", status)
-			logrus.Fatalf("Please commit these changes and run validation again.")
+		if err := validate.StatusExceptions(status); err != nil {
+			logrus.Fatal(err)
 		}
+
 		logrus.Infof("Successfully validated that current charts and assets are up to date.")
 	}
 

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -278,6 +278,32 @@ func (g *Git) CheckFileExists(file, branch string) error {
 	return exec.Command("git", "-C", g.Dir, "cat-file", "-e", target).Run()
 }
 
+// FullReset performs a hard reset, cleans the repository and restores it
+func (g *Git) FullReset() error {
+	if err := g.HardHEADReset(); err != nil {
+		return err
+	}
+	if err := g.ForceClean(); err != nil {
+		return err
+	}
+	return g.Restore()
+}
+
+// HardHEADReset = git reset --hard HEAD
+func (g *Git) HardHEADReset() error {
+	return exec.Command("git", "-C", g.Dir, "reset", "--hard", "HEAD").Run()
+}
+
+// ForceClean = git clean -fdx
+func (g *Git) ForceClean() error {
+	return exec.Command("git", "-C", g.Dir, "clean", "-fdx").Run()
+}
+
+// Restore = git restore .
+func (g *Git) Restore() error {
+	return exec.Command("git", "-C", g.Dir, "restore", ".").Run()
+}
+
 // ResetHEAD resets the HEAD of the git repository
 // ex: git reset HEAD
 func (g *Git) ResetHEAD() error {


### PR DESCRIPTION
Problem: https://github.com/rancher/charts/actions/runs/13507548706/job/37740519720?pr=5210

--- 

Some old charts have merged `.orig` files. 
There is nothing we can do about it because we can't modify already released charts. 

These `.orig` files do not break anything. 
