### PR TITLE
fixing missing configuration.yaml value because of cache reset

### DIFF
--- a/main.go
+++ b/main.go
@@ -880,6 +880,7 @@ func chartBump(c *cli.Context) {
 	}
 
 	repoRoot := getRepoRoot()
+	ChartsScriptOptionsFile = "configuration.yaml"
 	chartsScriptOptions := parseScriptOptions()
 
 	bump, err := auto.SetupBump(repoRoot, CurrentPackage, Branch, chartsScriptOptions)


### PR DESCRIPTION
After v1.5.1 release there was a small bug preventing auto-chart-bumps. 

The cache reset at the beginning of the command was erasing a path to the configuration.yaml file. 

