### PR TITLE
auto chart bump log improvements

### DIFF
--- a/pkg/auto/chart_bump.go
+++ b/pkg/auto/chart_bump.go
@@ -240,6 +240,11 @@ func (b *Bump) BumpChart(ctx context.Context) error {
 		return err
 	}
 
+	if err := git.Status(ctx); err != nil {
+		logger.Log(ctx, slog.LevelError, "error while checking git status", logger.Err(err))
+		return err
+	}
+
 	if err := git.AddAndCommit("make prepare"); err != nil {
 		logger.Log(ctx, slog.LevelError, "error while adding and committing after make prepare", logger.Err(err))
 		return err
@@ -251,6 +256,11 @@ func (b *Bump) BumpChart(ctx context.Context) error {
 			logger.Log(ctx, slog.LevelError, "error while downloading icon", logger.Err(err))
 			return err
 		}
+	}
+
+	if err := git.Status(ctx); err != nil {
+		logger.Log(ctx, slog.LevelError, "error while checking git status", logger.Err(err))
+		return err
 	}
 
 	if clean, _ := git.StatusProcelain(ctx); !clean {
@@ -272,6 +282,11 @@ func (b *Bump) BumpChart(ctx context.Context) error {
 		return err
 	}
 
+	if err := git.Status(ctx); err != nil {
+		logger.Log(ctx, slog.LevelError, "error while checking git status", logger.Err(err))
+		return err
+	}
+
 	if clean, _ := git.StatusProcelain(ctx); !clean {
 		if err := git.AddAndCommit("make patch"); err != nil {
 			return err
@@ -284,9 +299,19 @@ func (b *Bump) BumpChart(ctx context.Context) error {
 		return err
 	}
 
+	if err := git.Status(ctx); err != nil {
+		logger.Log(ctx, slog.LevelError, "error while checking git status", logger.Err(err))
+		return err
+	}
+
 	// make charts - generate new assets and charts overwriting logo
 	if err := b.Pkg.GenerateCharts(ctx, b.configOptions.OmitBuildMetadataOnExport); err != nil {
 		logger.Log(ctx, slog.LevelError, "error while generating charts", logger.Err(err))
+		return err
+	}
+
+	if err := git.Status(ctx); err != nil {
+		logger.Log(ctx, slog.LevelError, "error while checking git status", logger.Err(err))
 		return err
 	}
 
@@ -318,9 +343,19 @@ func (b *Bump) BumpChart(ctx context.Context) error {
 		}
 	}
 
+	if err := git.Status(ctx); err != nil {
+		logger.Log(ctx, slog.LevelError, "error while checking git status", logger.Err(err))
+		return err
+	}
+
 	// modify the release.yaml
 	if err := b.updateReleaseYaml(ctx, targetCharts); err != nil {
 		logger.Log(ctx, slog.LevelError, "error while updating release.yaml", logger.Err(err))
+		return err
+	}
+
+	if err := git.Status(ctx); err != nil {
+		logger.Log(ctx, slog.LevelError, "error while checking git status", logger.Err(err))
 		return err
 	}
 

--- a/pkg/charts/parse.go
+++ b/pkg/charts/parse.go
@@ -60,7 +60,6 @@ func ListPackages(ctx context.Context, repoRoot string, specificPackage string) 
 		if len(specificPackage) > 0 {
 			packagePrefix := filepath.Join(path.RepositoryPackagesDir, specificPackage)
 			if dirPath != packagePrefix && !strings.HasPrefix(dirPath, packagePrefix+"/") {
-				logger.Log(ctx, slog.LevelDebug, "ignore package based on prefix", slog.String("dirPath", dirPath), slog.String("packagePrefix", packagePrefix))
 				// Ignore packages not selected by specificPackage
 				return nil
 			}
@@ -77,6 +76,8 @@ func ListPackages(ctx context.Context, repoRoot string, specificPackage string) 
 			return err
 		}
 		packageList = append(packageList, packageName)
+		logger.Log(ctx, slog.LevelDebug, "package list", slog.Any("packageList", packageList))
+
 		return nil
 	}
 

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -48,7 +48,6 @@ func GetRelativePath(fs billy.Filesystem, abspath string) (string, error) {
 // PathExists checks if a path exists on the filesystem or returns an error
 func PathExists(ctx context.Context, fs billy.Filesystem, path string) (bool, error) {
 	absPath := GetAbsPath(fs, path)
-	logger.Log(ctx, slog.LevelDebug, "checking if path exists", slog.String("absPath", absPath))
 
 	_, err := os.Stat(absPath)
 	if err == nil {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -341,3 +341,14 @@ func (g *Git) getUpstreamRemote() (string, error) {
 
 	return upstreamRemote, nil
 }
+
+// Status prints the status of the git repository
+// equivalent to: git status --untracked-files=all --short
+func (g *Git) Status(ctx context.Context) error {
+	logger.Log(ctx, slog.LevelDebug, "git status -u -s")
+
+	cmd := exec.Command("git", "-C", g.Dir, "status", "--untracked-files=all", "--short")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -259,12 +259,18 @@ func (g *Git) StatusProcelain(ctx context.Context) (bool, error) {
 // equivalent to: git add -A && git commit -m message
 func (g *Git) AddAndCommit(message string) error {
 	// Stage all changes, including deletions
-	if err := exec.Command("git", "-C", g.Dir, "add", "-A").Run(); err != nil {
+	cmd := exec.Command("git", "-C", g.Dir, "add", "-A")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
 		return err
 	}
 
 	// Commit the staged changes
-	return exec.Command("git", "commit", "-m", message).Run()
+	cmd2 := exec.Command("git", "commit", "-m", message)
+	cmd2.Stdout = os.Stdout
+	cmd2.Stderr = os.Stderr
+	return cmd2.Run()
 }
 
 // PushBranch pushes the current branch to a given remote name


### PR DESCRIPTION
- Improving logging with the new `slog` for `auto chart bumps`. 
- Using `git status -u -s` for logging several results of `make commands` inside `auto chart bumps` 
- Removing flooded logs