### PR TITLE
pull icons during release command

### DIFF
--- a/main.go
+++ b/main.go
@@ -900,6 +900,10 @@ func release(c *cli.Context) {
 	CurrentAsset = release.Chart + "/" + release.AssetTgz
 	unzipAssets(c)
 
+	if err := release.PullIcon(ctx, rootFs); err != nil {
+		logger.Fatal(ctx, fmt.Errorf("failed to pull icon: %w", err).Error())
+	}
+
 	// update release.yaml
 	if err := release.UpdateReleaseYaml(); err != nil {
 		logger.Fatal(ctx, fmt.Errorf("failed to update release.yaml: %w", err).Error())

--- a/pkg/auto/release.go
+++ b/pkg/auto/release.go
@@ -5,13 +5,18 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
+	"strings"
 
+	"github.com/go-git/go-billy/v5"
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
 	"github.com/rancher/charts-build-scripts/pkg/git"
 	"github.com/rancher/charts-build-scripts/pkg/lifecycle"
+	"github.com/rancher/charts-build-scripts/pkg/logger"
 	"github.com/rancher/charts-build-scripts/pkg/path"
 	"gopkg.in/yaml.v3"
+	helmChartutil "helm.sh/helm/v3/pkg/chartutil"
 )
 
 // Release holds necessary metadata to release a chart version
@@ -153,4 +158,56 @@ func (r *Release) UpdateReleaseYaml() error {
 	}
 
 	return nil
+}
+
+// PullIcon will pull the icon from the chart and save it to the local assets/logos directory
+func (r *Release) PullIcon(ctx context.Context, rootFs billy.Filesystem) error {
+	logger.Log(ctx, slog.LevelInfo, "starting to pull icon process")
+
+	// Get Chart.yaml path and load it
+	chartYamlPath := path.RepositoryChartsDir + "/" + r.Chart + "/" + r.ChartVersion + "/Chart.yaml"
+	absChartPath := filesystem.GetAbsPath(rootFs, chartYamlPath)
+
+	// Load Chart.yaml file
+	chartMetadata, err := helmChartutil.LoadChartfile(absChartPath)
+	if err != nil {
+		return fmt.Errorf("could not load %s: %s", chartYamlPath, err)
+	}
+
+	logger.Log(ctx, slog.LevelDebug, "checking if chart has downloaded icon")
+	iconField := chartMetadata.Icon
+
+	// Check file prefix if it is a URL just skip this process
+	if !strings.HasPrefix(iconField, "file://") {
+		logger.Log(ctx, slog.LevelInfo, "icon path is not a file:// prefix")
+		return nil
+	}
+
+	relativeIconPath, _ := strings.CutPrefix(iconField, "file://")
+
+	// Check if icon is already present
+	exists, err := filesystem.PathExists(ctx, rootFs, relativeIconPath)
+	if err != nil {
+		return err
+	}
+
+	// Icon is already present, no need to pull it
+	if exists {
+		logger.Log(ctx, slog.LevelDebug, "icon already exists")
+		return nil
+	}
+
+	// Check if the icon exists in the dev branch
+	if err := r.git.CheckFileExists(relativeIconPath, r.VR.DevBranch); err != nil {
+		logger.Log(ctx, slog.LevelError, "icon file not found in dev branch but should", slog.String("icon", relativeIconPath), logger.Err(err))
+		return fmt.Errorf("icon file not found in dev branch but should: %w", err)
+	}
+
+	// checkout the icon file from the dev branch
+	if err := r.git.CheckoutFile(r.VR.DevBranch, relativeIconPath); err != nil {
+		return err
+	}
+
+	// git reset return
+	return r.git.ResetHEAD()
 }


### PR DESCRIPTION
The `make release ....` command did not pull newer downloaded icons. 

Adding this feature was usually done manually at the end of the release. 

There is a check in place for if the icon has the proper prefix: 
- `file:///`
- `https://`

