### PR TITLE
adding log for the initial logger

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,8 +126,9 @@ func init() {
 		}
 	}
 	// Create a new slog logger with tint handler
-	logger := slog.New(tint.NewHandler(os.Stderr, tintOptions))
-	slog.SetDefault(logger)
+	newLogger := slog.New(tint.NewHandler(os.Stderr, tintOptions))
+	slog.SetDefault(newLogger)
+	logger.Log(context.Background(), slog.LevelInfo, "charts-build-scripts", slog.String("LOG", os.Getenv("LOG")))
 }
 
 func main() {


### PR DESCRIPTION
Debugging CI failures without DBG level logging: https://github.com/rancher/charts/actions/runs/14406869601/job/40405400686

But these CI failures should have DBG level logging.  
