### PR TITLE
Validate icons are downloaded

### DIFF
--- a/main.go
+++ b/main.go
@@ -464,12 +464,16 @@ func main() {
 			Flags:  []cli.Flag{branchFlag},
 		},
 		{
-			Name: "chart-bump",
-			Usage: `Generate a new chart bump PR.
-			`,
+			Name:   "chart-bump",
+			Usage:  `Generate a new chart bump PR.`,
 			Action: chartBump,
 			Before: setupCache,
 			Flags:  []cli.Flag{packageFlag, branchFlag, overrideVersionFlag, multiRCFlag},
+		},
+		{
+			Name:   "validate-icons",
+			Usage:  "used by CI to check if icons were downloaded",
+			Action: validateIcons,
 		},
 	}
 
@@ -562,6 +566,15 @@ func downloadIcon(c *cli.Context) {
 		if err != nil {
 			logger.Fatal(ctx, err.Error())
 		}
+	}
+}
+
+func validateIcons(c *cli.Context) {
+	ctx := context.Background()
+	getRepoRoot()
+	rootFs := filesystem.GetFilesystem(RepoRoot)
+	if err := auto.ValidateIcons(ctx, rootFs); err != nil {
+		logger.Fatal(ctx, err.Error())
 	}
 }
 

--- a/pkg/auto/chart_bump.go
+++ b/pkg/auto/chart_bump.go
@@ -260,8 +260,8 @@ func (b *Bump) BumpChart(ctx context.Context, versionOverride string, multiRCs b
 		return err
 	}
 
-	// Download logo at assets/logos (webhook and fleet are exceptions)
-	if b.targetChart != "fleet" && b.targetChart != "rancher-webhook" {
+	// Download logo at assets/logos
+	if !isIconException(b.targetChart) {
 		if err := b.Pkg.DownloadIcon(ctx); err != nil {
 			logger.Log(ctx, slog.LevelError, "error while downloading icon", logger.Err(err))
 			return err

--- a/pkg/auto/release.go
+++ b/pkg/auto/release.go
@@ -197,7 +197,7 @@ func (r *Release) PullIcon(ctx context.Context, rootFs billy.Filesystem) error {
 	// Check if the icon exists in the dev branch
 	if err := r.git.CheckFileExists(relativeIconPath, r.VR.DevBranch); err != nil {
 		logger.Log(ctx, slog.LevelError, "icon file not found in dev branch but should", slog.String("icon", relativeIconPath), logger.Err(err))
-		return fmt.Errorf("icon file not found in dev branch but should: %w", err)
+		return errors.New("icon file not found in dev branch but should: " + err.Error())
 	}
 
 	// checkout the icon file from the dev branch
@@ -217,7 +217,7 @@ func loadChartYaml(rootFs billy.Filesystem, chart string, chartVersion string) (
 	// Load Chart.yaml file
 	chartMetadata, err := helmChartutil.LoadChartfile(absChartPath)
 	if err != nil {
-		return nil, fmt.Errorf("could not load %s: %s", chartYamlPath, err)
+		return nil, errors.New("could not load: " + chartYamlPath + " err: " + err.Error())
 	}
 
 	return chartMetadata, nil

--- a/pkg/auto/validate.go
+++ b/pkg/auto/validate.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/Masterminds/semver"
 	"github.com/go-git/go-billy/v5"
@@ -258,5 +259,68 @@ func CompareIndexFiles(ctx context.Context, rootFs billy.Filesystem) error {
 		logger.Log(ctx, slog.LevelDebug, "index.yaml files are different", slog.String("diff", diff))
 		return errors.New("index.yaml files are different at git repository and charts.rancher.io")
 	}
+	return nil
+}
+
+// ValidateIcons will check if the icons are present in the local filesystem and if they are not, it will return an error.
+func ValidateIcons(ctx context.Context, rootFs billy.Filesystem) error {
+	releaseOpts, err := options.LoadReleaseOptionsFromFile(ctx, rootFs, path.RepositoryReleaseYaml)
+	if err != nil {
+		return err
+	}
+
+	releaseOpts.SortBySemver(ctx)
+
+	logger.Log(ctx, slog.LevelInfo, "checking if icons are present in the local filesystem")
+	for chart, versions := range releaseOpts {
+		if isIconException(chart) {
+			logger.Log(ctx, slog.LevelDebug, "skipping icon check for:", slog.String("chart", chart))
+			continue
+		}
+
+		version := versions[len(versions)-1]
+		logger.Log(ctx, slog.LevelDebug, "checking chart", slog.String("chart", chart))
+		if err := loadAndCheckIconPrefix(ctx, rootFs, chart, version); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func isIconException(chart string) bool {
+	if strings.Contains(chart, "-crd") ||
+		strings.Contains(chart, "fleet") ||
+		strings.Contains(chart, "harvester") ||
+		chart == "rancher-webhook" ||
+		chart == "rancher-aks-operator" ||
+		chart == "rancher-eks-operator" ||
+		chart == "rancher-gke-operator" ||
+		chart == "rancher-provisioning-capi" ||
+		chart == "rancher-pushprox" ||
+		chart == "rancher-wins-upgrader" ||
+		chart == "remotedialer-proxy" ||
+		chart == "system-upgrade-controller" ||
+		chart == "ui-plugin-operator" {
+		return true
+	}
+	return false
+}
+
+func loadAndCheckIconPrefix(ctx context.Context, rootFs billy.Filesystem, chart string, chartVersion string) error {
+	metaData, err := loadChartYaml(rootFs, chart, chartVersion)
+	if err != nil {
+		return err
+	}
+
+	logger.Log(ctx, slog.LevelDebug, "checking if chart has downloaded icon")
+	iconField := metaData.Icon
+
+	// Check file prefix if it is a URL just skip this process
+	if !strings.HasPrefix(iconField, "file://") {
+		logger.Log(ctx, slog.LevelError, "icon path is not a file:// prefix")
+		return errors.New("icon path is not a file:// prefix, after make prepare, you need to run make icon for chart:" + chart)
+	}
+
 	return nil
 }

--- a/pkg/options/validate.go
+++ b/pkg/options/validate.go
@@ -2,13 +2,18 @@ package options
 
 import (
 	"context"
+	"log/slog"
 	"os"
+	"sort"
+	"strings"
 
+	"github.com/Masterminds/semver"
 	"github.com/hashicorp/go-version"
 	"golang.org/x/exp/slices"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
+	"github.com/rancher/charts-build-scripts/pkg/logger"
 	"gopkg.in/yaml.v2"
 )
 

--- a/pkg/options/validate.go
+++ b/pkg/options/validate.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver"
-	"github.com/hashicorp/go-version"
 	"golang.org/x/exp/slices"
 
 	"github.com/go-git/go-billy/v5"
@@ -136,26 +135,6 @@ func (r ReleaseOptions) SortBySemver(ctx context.Context) {
 			return vi.LessThan(vj)
 		})
 	}
-}
-
-// CompareVersions compares two semantic versions and determines ascending ordering
-func CompareVersions(a string, b string) int {
-	v1, err := version.NewVersion(a)
-	if err != nil {
-		return 0
-	}
-
-	v2, err := version.NewVersion(b)
-	if err != nil {
-		return 0
-	}
-
-	if v1.LessThan(v2) {
-		return -1
-	} else if v1.GreaterThan(v2) {
-		return 1
-	}
-	return 0
 }
 
 // WriteToFile marshals the struct to yaml and writes it into the path specified

--- a/pkg/options/validate.go
+++ b/pkg/options/validate.go
@@ -87,14 +87,54 @@ func LoadReleaseOptionsFromFile(ctx context.Context, fs billy.Filesystem, path s
 	if err != nil {
 		return releaseOptions, err
 	}
+
 	return releaseOptions, yaml.Unmarshal(releaseOptionsBytes, &releaseOptions)
 }
 
 // SortBySemver sorts the version strings in release options according to semver constraints
-func (r ReleaseOptions) SortBySemver() {
-	for chartName, versions := range r {
-		slices.SortFunc(versions, CompareVersions)
-		r[chartName] = versions
+func (r ReleaseOptions) SortBySemver(ctx context.Context) {
+	for _, versions := range r {
+		if len(versions) <= 1 {
+			continue
+		}
+		sort.Slice(versions, func(i, j int) bool {
+			// If the version is not a valid semver, we can't compare it
+			// so we return false to keep the original order
+			vi, err := semver.NewVersion(versions[i])
+			if err != nil {
+				logger.Log(ctx, slog.LevelError, "error parsing version", logger.Err(err))
+				return false
+			}
+			vj, err := semver.NewVersion(versions[j])
+			if err != nil {
+				logger.Log(ctx, slog.LevelError, "error parsing version", logger.Err(err))
+				return false
+			}
+
+			// if versions are equal, compare metadata (probably dealing with RC versions)
+			if vi.Equal(vj) {
+				if vi.Metadata() == "" && vj.Metadata() == "" {
+					return false
+				}
+				viMetadata, _ := strings.CutPrefix(vi.Metadata(), "up")
+				mi, err := semver.NewVersion(viMetadata)
+				if err != nil {
+					logger.Log(ctx, slog.LevelError, "error parsing version", logger.Err(err))
+					return false
+				}
+
+				vjMetadata, _ := strings.CutPrefix(vj.Metadata(), "up")
+				mj, err := semver.NewVersion(vjMetadata)
+				if err != nil {
+					logger.Log(ctx, slog.LevelError, "error parsing version", logger.Err(err))
+					return false
+				}
+
+				return mi.LessThan(mj)
+			}
+
+			return vi.LessThan(vj)
+		})
 	}
 }
 
@@ -120,7 +160,7 @@ func CompareVersions(a string, b string) int {
 
 // WriteToFile marshals the struct to yaml and writes it into the path specified
 func (r ReleaseOptions) WriteToFile(ctx context.Context, fs billy.Filesystem, path string) error {
-	r.SortBySemver()
+	r.SortBySemver(ctx)
 
 	releaseOptionsBytes, err := yaml.Marshal(r)
 	if err != nil {


### PR DESCRIPTION
In order to prevent this https://github.com/rancher/ecm-distro-tools/issues/553 from happening again. 

This check will ensure that every new chart has downloaded the icons file locally in the repository. 

If the chart owner has not downloaded, the CI will block that PR from merging. 

A few Charts can bypass this rule because they are auto-installable and have no icon to present in the UI.