### PR TITLE
exception for system install chart

### DIFF
--- a/pkg/auto/validate.go
+++ b/pkg/auto/validate.go
@@ -301,7 +301,8 @@ func isIconException(chart string) bool {
 		chart == "rancher-wins-upgrader" ||
 		chart == "remotedialer-proxy" ||
 		chart == "system-upgrade-controller" ||
-		chart == "ui-plugin-operator" {
+		chart == "ui-plugin-operator" ||
+		chart == "rancher-csp-adapter" {
 		return true
 	}
 	return false


### PR DESCRIPTION
Adding `rancher-csp-adapter` chart to the list of icon exceptions. 

This chart does not have an Icon since it is not listed in the MarketPlace