### PR TITLE
safe-check nil pointer

### DIFF
--- a/pkg/auto/release.go
+++ b/pkg/auto/release.go
@@ -118,6 +118,10 @@ func readReleaseYaml(ctx context.Context, path string) (map[string][]string, err
 		return nil, err
 	}
 
+	if releaseVersions == nil {
+		return map[string][]string{}, nil
+	}
+
 	return *releaseVersions, nil
 }
 


### PR DESCRIPTION
Following up from previous PR: https://github.com/rancher/charts-build-scripts/pull/232

This safe-check was missing. 