### PR TITLE
handling cases when repository does not exist

### DIFF
--- a/pkg/registries/remote.go
+++ b/pkg/registries/remote.go
@@ -18,6 +18,7 @@ import (
 	authn "github.com/google/go-containerregistry/pkg/authn"
 	name "github.com/google/go-containerregistry/pkg/name"
 	remote "github.com/google/go-containerregistry/pkg/v1/remote"
+	transport "github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
 const (
@@ -97,7 +98,9 @@ var listRegistryImageTags = func(ctx context.Context, imageTagMap map[string][]s
 		}
 
 		logger.Log(ctx, slog.LevelDebug, "", slog.Any("tags", tags))
-		remoteImgTagMap[asset] = tags
+		if len(tags) > 0 {
+			remoteImgTagMap[asset] = tags
+		}
 	}
 
 	return remoteImgTagMap, nil
@@ -140,6 +143,15 @@ var fetchTagsFromRegistryRepo = func(ctx context.Context, registry, asset string
 	// but remote package handles pagination internally if needed
 	tags, err := remote.List(repo, options...)
 	if err != nil {
+		var transportError *transport.Error
+		if errors.As(err, &transportError) {
+			for _, d := range transportError.Errors {
+				if d.Code == "NAME_UNKNOWN" {
+					logger.Log(ctx, slog.LevelWarn, "repository not found", slog.String("repo", repo.Name()))
+					return []string{}, nil
+				}
+			}
+		}
 		logger.Log(ctx, slog.LevelError, "list failure", logger.Err(err))
 		return nil, err
 	}


### PR DESCRIPTION
Fixing broken GHA: https://github.com/rancher/charts/actions/runs/16608723676/job/46987028028?pr=5999

When the repository does not exist at staging registry, it should not throw an error.