### PR TITLE
small-fix

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -84,7 +84,7 @@ func CreateOrUpdateHelmIndex(ctx context.Context, rootFs billy.Filesystem) error
 // Only -alpha., -beta., and -rc. prerelease identifiers are allowed
 // Returns an error if any version contains an invalid prerelease identifier
 func CheckVersionStandards(ctx context.Context, new *helmRepo.IndexFile) error {
-	allowedPrereleases := []string{"-alpha.", "-beta.", "-rc", "-rancher."}
+	allowedPrereleases := []string{"-alpha.", "-beta.", "-rc", "-rancher"}
 	logger.Log(ctx, slog.LevelInfo, "checking version standars", slog.Any("allowed", allowedPrereleases))
 
 	for chartName, chartVersions := range new.Entries {


### PR DESCRIPTION
Removing "." from version standard verification to allow deprecated versions of vsphere to pass the verification for version standards. 