### PR TITLE
Fix setup action install dir

### DIFF
--- a/actions/setup-charts-build-scripts/action.yml
+++ b/actions/setup-charts-build-scripts/action.yml
@@ -30,7 +30,7 @@ runs:
   using: 'composite'
   steps:
   - name: install charts-build-scripts
-    shell: bash
+    shell: sh
     env:
       VERSION: ${{ inputs.version }}
       USE_SUDO: ${{ inputs.use-sudo }}


### PR DESCRIPTION
The $HOME env was not expanded, and the literal '$HOME' directory was used.
New instructions were added to the action, and the env expansion was moved to the install script and not the input.