### PR TITLE
fix(icons): respect doNotRelease flag in make icon

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,10 @@ replace github.com/Masterminds/semver/v3 => github.com/Masterminds/semver/v3 v3.
 // Our chart versioning: <version>+up<upstream> (e.g., 108.0.0+up0.25.0-rc.0)
 exclude helm.sh/helm/v4 v4.0.0
 
-require github.com/rancherlabs/slsactl v0.1.30
+require (
+	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/rancherlabs/slsactl v0.1.30
+)
 
 require (
 	github.com/Masterminds/semver v1.5.0
@@ -60,7 +63,6 @@ require (
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/pkg/charts/icons.go
+++ b/pkg/charts/icons.go
@@ -25,6 +25,11 @@ import (
 func (p *Package) DownloadIcon(ctx context.Context) error {
 	logger.Log(ctx, slog.LevelInfo, "make icon")
 
+	if p.DoNotRelease {
+		logger.Log(ctx, slog.LevelInfo, "skipping package marked doNotRelease")
+		return nil
+	}
+
 	exists, err := filesystem.PathExists(ctx, p.fs, path.RepositoryChartsDir)
 	if err != nil {
 		return fmt.Errorf("failed to check for charts dir: %w", err)
@@ -44,9 +49,9 @@ func (p *Package) DownloadIcon(ctx context.Context) error {
 		logger.Log(ctx, slog.LevelDebug, "chart icon is pointing to a remote url", slog.String("url", chart.Metadata.Icon))
 
 		// download icon and change the icon property to point to it
-		p, err := downloadIcon(ctx, p.rootFs, chart.Metadata)
+		iconPath, err := downloadIcon(ctx, p.rootFs, chart.Metadata)
 		if err == nil { // managed to download the icon and save it locally
-			chart.Metadata.Icon = fmt.Sprintf("file://%s", p)
+			chart.Metadata.Icon = fmt.Sprintf("file://%s", iconPath)
 		} else {
 			logger.Log(ctx, slog.LevelError, "failed to download icon", logger.Err(err))
 		}

--- a/pkg/charts/icons_test.go
+++ b/pkg/charts/icons_test.go
@@ -21,7 +21,7 @@ func Test_downloadIcon(t *testing.T) {
 	}{
 		{
 			name: "#1",
-			handler: func(w http.ResponseWriter, r *http.Request) {
+			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "image/png")
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte("fake-icon-data"))
@@ -35,7 +35,7 @@ func Test_downloadIcon(t *testing.T) {
 		},
 		{
 			name: "#3 - non-200 status",
-			handler: func(w http.ResponseWriter, r *http.Request) {
+			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "image/png")
 				w.WriteHeader(http.StatusNotFound)
 			},
@@ -43,7 +43,7 @@ func Test_downloadIcon(t *testing.T) {
 		},
 		{
 			name: "#4 - unknown Content-Type with no extension",
-			handler: func(w http.ResponseWriter, r *http.Request) {
+			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/x-test-no-extension")
 				w.WriteHeader(http.StatusOK)
 			},
@@ -55,7 +55,7 @@ func Test_downloadIcon(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var iconURL string
 			if tt.serverDown {
-				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+				ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
 				iconURL = ts.URL
 				ts.Close()
 			} else {
@@ -85,4 +85,45 @@ func Test_downloadIcon(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPackage_DownloadIcon_DoNotRelease(t *testing.T) {
+	ctx := context.Background()
+
+	// Create package with DoNotRelease flag
+	pkg := &Package{
+		Name:         "test-chart",
+		DoNotRelease: true,
+		fs:           memfs.New(),
+		rootFs:       memfs.New(),
+	}
+
+	// Create charts directory to simulate prepared package
+	if err := pkg.fs.MkdirAll("charts", os.ModePerm); err != nil {
+		t.Fatalf("failed to create charts dir: %v", err)
+	}
+
+	// DownloadIcon should return early without error
+	err := pkg.DownloadIcon(ctx)
+	assert.NoError(t, err)
+
+	// Verify no icon was downloaded (assets/logos should not exist)
+	exists, _ := pkg.rootFs.Stat("assets/logos")
+	assert.Nil(t, exists, "assets/logos should not be created for doNotRelease packages")
+}
+
+func TestPackage_DownloadIcon_NotDoNotRelease(t *testing.T) {
+	ctx := context.Background()
+
+	// Create package WITHOUT DoNotRelease flag
+	pkg := &Package{
+		Name:         "test-chart",
+		DoNotRelease: false,
+		fs:           memfs.New(),
+		rootFs:       memfs.New(),
+	}
+
+	// Without charts directory, should fail with specific message
+	err := pkg.DownloadIcon(ctx)
+	assert.NoError(t, err, "should return nil when charts dir doesn't exist")
 }


### PR DESCRIPTION
## Summary
- Add doNotRelease check to DownloadIcon to skip icon generation for packages marked doNotRelease
- Fix variable shadowing in DownloadIcon (iconPath vs receiver p)
- Add tests for doNotRelease behavior in icon download

## Tests
- TestPackage_DownloadIcon_DoNotRelease: verifies packages with doNotRelease skip icon processing
- TestPackage_DownloadIcon_NotDoNotRelease: verifies normal packages proceed as expected