### PR TITLE
respect gitignore during validation cleanup

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -339,7 +339,7 @@ func (g *Git) HardHEADReset() error {
 
 // ForceClean = git clean -fdx
 func (g *Git) ForceClean() error {
-	return exec.Command("git", "-C", g.Dir, "clean", "-fdx").Run()
+	return exec.Command("git", "-C", g.Dir, "clean", "-fd").Run()
 }
 
 // Restore = git restore .

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -233,15 +233,28 @@ func StatusExceptions(ctx context.Context, status git.Status) error {
 			return errors.New("repository must be clean to run validation")
 		}
 
+		logger.Log(ctx, slog.LevelDebug, "git is not clean but expected")
+
+		// Log which files will be reset
+		var changedFiles []string
+		for file := range status {
+			changedFiles = append(changedFiles, file)
+		}
+		logger.Log(ctx, slog.LevelInfo, "resetting exception files", slog.Any("files", changedFiles))
+
 		g, err := bashGit.OpenGitRepo(ctx, ".")
 		if err != nil {
 			return err
 		}
+
+		logger.Log(ctx, slog.LevelDebug, "executing full reset")
 		if err := g.FullReset(); err != nil {
 			return err
 		}
-	}
 
+		logger.Log(ctx, slog.LevelInfo, "successfully reset exception files")
+	}
+	logger.Log(ctx, slog.LevelInfo, "git is clean")
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Removes `-x` flag from `git clean` in `ForceClean` to preserve gitignored files like `bin/charts-build-scripts` during validation exception resets
- Adds logging in `StatusExceptions` to show which files are being reset before cleanup and confirm success after