### PR TITLE
fix(helm): correct version sorting for chart versions with same upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ templates/.DS_Store
 .vscode
 dist/
 *.out
+__debug_bin*
+__debug_test

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -208,13 +207,14 @@ func SortVersions(index *helmRepo.IndexFile) {
 // Returns true if versionA should come before versionB (descending order)
 // Handles alpha, beta, rc, and stable versions
 func compareVersions(versionA, versionB string) bool {
-	// Parse both versions
-	baseA, typeA, numA, isPrereleaseA := parseVersionWithPrerelease(versionA)
-	baseB, typeB, numB, isPrereleaseB := parseVersionWithPrerelease(versionB)
+	// Split versions into upstream and chart parts
+	// Format: <upstream_version>+up<chart_version>
+	upstreamA, chartA := splitUpstreamChart(versionA)
+	upstreamB, chartB := splitUpstreamChart(versionB)
 
-	// Parse base versions using semver
-	semverA, errA := semver.NewVersion(baseA)
-	semverB, errB := semver.NewVersion(baseB)
+	// Parse upstream versions using semver
+	semverUpstreamA, errA := semver.NewVersion(upstreamA)
+	semverUpstreamB, errB := semver.NewVersion(upstreamB)
 
 	if errA != nil {
 		return false // push invalid to end
@@ -223,71 +223,41 @@ func compareVersions(versionA, versionB string) bool {
 		return true // push invalid to end
 	}
 
-	// If base versions are different, use semver comparison (descending)
-	if !semverA.Equal(semverB) {
-		return semverA.GreaterThan(semverB)
+	// If upstream versions are different, use semver comparison (descending)
+	if !semverUpstreamA.Equal(semverUpstreamB) {
+		return semverUpstreamA.GreaterThan(semverUpstreamB)
 	}
 
-	// Same base version - handle prerelease logic
-	// Compare prerelease types first (stable=4 > rc=3 > beta=2 > alpha=1)
-	if typeA != typeB {
-		return typeA > typeB // Higher type priority comes first
-	}
+	// Same upstream version - compare chart versions (the part after +up)
+	if chartA != "" && chartB != "" {
+		semverChartA, errA := semver.NewVersion(chartA)
+		semverChartB, errB := semver.NewVersion(chartB)
 
-	// Same prerelease type - compare numbers if both are prereleases
-	if isPrereleaseA && isPrereleaseB {
-		return numA > numB // Higher prerelease number comes first (descending)
-	}
+		if errA != nil {
+			return false // push invalid to end
+		}
+		if errB != nil {
+			return true // push invalid to end
+		}
 
-	// Both are stable with same base version - they're equal
-	return false
-}
-
-// parseVersionWithPrerelease extracts the base version, prerelease type, and prerelease number from a version string
-// Example: "108.0.0+up0.14.0-rc.1" returns ("108.0.0+up0.14.0", 3, 1, true)
-// Example: "108.0.0+up0.14.0-beta.2" returns ("108.0.0+up0.14.0", 2, 2, true)
-// Example: "108.0.0+up0.14.0-alpha.5" returns ("108.0.0+up0.14.0", 1, 5, true)
-// Example: "108.0.0+up0.14.0" returns ("108.0.0+up0.14.0", 4, 0, false) - stable version
-// Prerelease type priority: stable=4 > rc=3 > beta=2 > alpha=1
-func parseVersionWithPrerelease(version string) (baseVersion string, prereleaseType int, prereleaseNumber int, isPrerelease bool) {
-	// Split by '+' to separate version from build metadata
-	parts := strings.Split(version, "+")
-	if len(parts) != 2 {
-		// No build metadata, treat as stable
-		return version, 4, 0, false
-	}
-
-	baseVersionNum := parts[0]
-	buildMetadata := parts[1]
-
-	// Check for prerelease types in priority order: alpha, beta, rc
-	prereleaseTypes := []struct {
-		suffix   string
-		priority int
-	}{
-		{"-alpha.", 1},
-		{"-beta.", 2},
-		{"-rc.", 3},
-	}
-
-	for _, pt := range prereleaseTypes {
-		if strings.Contains(buildMetadata, pt.suffix) {
-			// Extract prerelease number
-			preParts := strings.Split(buildMetadata, pt.suffix)
-			if len(preParts) != 2 {
-				continue
-			}
-
-			preNum, err := strconv.Atoi(preParts[1])
-			if err != nil {
-				continue
-			}
-
-			// Return base version with the non-prerelease part of build metadata
-			return baseVersionNum + "+" + preParts[0], pt.priority, preNum, true
+		// Compare chart versions (descending)
+		// This automatically handles prereleases correctly per semver spec
+		if !semverChartA.Equal(semverChartB) {
+			return semverChartA.GreaterThan(semverChartB)
 		}
 	}
 
-	// No prerelease found, treat as stable
-	return version, 4, 0, false
+	// Versions are equal
+	return false
+}
+
+// splitUpstreamChart splits a version string into upstream and chart parts
+// Example: "109.0.1+up0.10.4-rc.1" returns ("109.0.1", "0.10.4-rc.1")
+// Example: "109.0.1" returns ("109.0.1", "")
+func splitUpstreamChart(version string) (upstream, chart string) {
+	parts := strings.Split(version, "+up")
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return version, ""
 }

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -15,7 +15,7 @@ func TestSortVersions(t *testing.T) {
 		expected []string // expected order of versions
 	}{
 		{
-			name: "stable versions only - should sort descending",
+			name: "1. stable versions only - should sort descending",
 			input: helmRepo.ChartVersions{
 				{Metadata: &helmChart.Metadata{Version: "108.0.0+up0.9.0"}},
 				{Metadata: &helmChart.Metadata{Version: "108.0.2+up0.9.2"}},
@@ -28,7 +28,7 @@ func TestSortVersions(t *testing.T) {
 			},
 		},
 		{
-			name: "stable + RCs with same base - stable first, then RCs descending",
+			name: "2. stable + RCs with same base - stable first, then RCs descending",
 			input: helmRepo.ChartVersions{
 				{Metadata: &helmChart.Metadata{Version: "108.0.0+up0.9.0-rc.1"}},
 				{Metadata: &helmChart.Metadata{Version: "108.0.0+up0.9.0"}},
@@ -41,7 +41,7 @@ func TestSortVersions(t *testing.T) {
 			},
 		},
 		{
-			name: "RCs only - should sort descending by RC number",
+			name: "3. RCs only - should sort descending by RC number",
 			input: helmRepo.ChartVersions{
 				{Metadata: &helmChart.Metadata{Version: "108.0.0+up0.9.0-rc.1"}},
 				{Metadata: &helmChart.Metadata{Version: "108.0.0+up0.9.0-rc.3"}},
@@ -54,7 +54,7 @@ func TestSortVersions(t *testing.T) {
 			},
 		},
 		{
-			name: "mixed base versions with RCs - sort by semver first",
+			name: "4. mixed base versions with RCs - sort by semver first",
 			input: helmRepo.ChartVersions{
 				{Metadata: &helmChart.Metadata{Version: "108.0.0+up0.9.0-rc.1"}},
 				{Metadata: &helmChart.Metadata{Version: "109.0.0+up0.10.0"}},
@@ -69,7 +69,7 @@ func TestSortVersions(t *testing.T) {
 			},
 		},
 		{
-			name: "alpha/beta/rc/stable - full prerelease hierarchy",
+			name: "5. alpha/beta/rc/stable - full prerelease hierarchy",
 			input: helmRepo.ChartVersions{
 				{Metadata: &helmChart.Metadata{Version: "108.0.0+up0.14.0-alpha.2"}},
 				{Metadata: &helmChart.Metadata{Version: "108.0.0+up0.14.0-rc.1"}},
@@ -91,6 +91,103 @@ func TestSortVersions(t *testing.T) {
 				"108.0.0+up0.14.0-alpha.3",
 				"108.0.0+up0.14.0-alpha.2",
 				"108.0.0+up0.14.0-alpha.1",
+			},
+		},
+		{
+			name: "6.same upstream version, different chart versions after +up",
+			input: helmRepo.ChartVersions{
+				{Metadata: &helmChart.Metadata{Version: "109.0.1+up0.10.1-rc.2"}},
+				{Metadata: &helmChart.Metadata{Version: "109.0.1+up0.10.4-rc.1"}},
+				{Metadata: &helmChart.Metadata{Version: "109.0.1+up0.10.1-rc.1"}},
+				{Metadata: &helmChart.Metadata{Version: "109.0.0+up0.10.0"}},
+			},
+			expected: []string{
+				"109.0.1+up0.10.4-rc.1", // 0.10.4 > 0.10.1, should be first
+				"109.0.1+up0.10.1-rc.2", // then 0.10.1-rc.2
+				"109.0.1+up0.10.1-rc.1", // then 0.10.1-rc.1
+				"109.0.0+up0.10.0",      // oldest upstream version last
+			},
+		},
+		{
+			name: "7. edge case - versions without +up format",
+			input: helmRepo.ChartVersions{
+				{Metadata: &helmChart.Metadata{Version: "1.0.0"}},
+				{Metadata: &helmChart.Metadata{Version: "1.2.0"}},
+				{Metadata: &helmChart.Metadata{Version: "1.1.0"}},
+			},
+			expected: []string{
+				"1.2.0",
+				"1.1.0",
+				"1.0.0",
+			},
+		},
+		{
+			name: "8. edge case - mix of +up and plain versions",
+			input: helmRepo.ChartVersions{
+				{Metadata: &helmChart.Metadata{Version: "109.0.1+up0.10.1"}},
+				{Metadata: &helmChart.Metadata{Version: "109.0.1"}},
+				{Metadata: &helmChart.Metadata{Version: "109.0.0+up0.10.0"}},
+				{Metadata: &helmChart.Metadata{Version: "109.0.0"}},
+			},
+			expected: []string{
+				"109.0.1+up0.10.1", // upstream 109.0.1 with chart version
+				"109.0.1",          // upstream 109.0.1 without chart version
+				"109.0.0+up0.10.0", // upstream 109.0.0 with chart version
+				"109.0.0",          // upstream 109.0.0 without chart version
+			},
+		},
+		{
+			name: "9. edge case - same upstream and chart, different prerelease types",
+			input: helmRepo.ChartVersions{
+				{Metadata: &helmChart.Metadata{Version: "109.0.1+up0.10.1-alpha.1"}},
+				{Metadata: &helmChart.Metadata{Version: "109.0.1+up0.10.1"}},
+				{Metadata: &helmChart.Metadata{Version: "109.0.1+up0.10.1-rc.1"}},
+				{Metadata: &helmChart.Metadata{Version: "109.0.1+up0.10.1-beta.1"}},
+			},
+			expected: []string{
+				"109.0.1+up0.10.1",         // stable first
+				"109.0.1+up0.10.1-rc.1",    // rc
+				"109.0.1+up0.10.1-beta.1",  // beta
+				"109.0.1+up0.10.1-alpha.1", // alpha last
+			},
+		},
+		{
+			name: "10. edge case - large version numbers",
+			input: helmRepo.ChartVersions{
+				{Metadata: &helmChart.Metadata{Version: "999.999.999+up999.999.999"}},
+				{Metadata: &helmChart.Metadata{Version: "999.999.998+up999.999.999"}},
+				{Metadata: &helmChart.Metadata{Version: "999.999.999+up999.999.998"}},
+			},
+			expected: []string{
+				"999.999.999+up999.999.999",
+				"999.999.999+up999.999.998",
+				"999.999.998+up999.999.999",
+			},
+		},
+		{
+			name: "11. edge case - zero versions",
+			input: helmRepo.ChartVersions{
+				{Metadata: &helmChart.Metadata{Version: "0.0.1+up0.0.1"}},
+				{Metadata: &helmChart.Metadata{Version: "0.0.0+up0.0.1"}},
+				{Metadata: &helmChart.Metadata{Version: "0.0.1+up0.0.0"}},
+			},
+			expected: []string{
+				"0.0.1+up0.0.1",
+				"0.0.1+up0.0.0",
+				"0.0.0+up0.0.1",
+			},
+		},
+		{
+			name: "12. edge case - chart version with major changes",
+			input: helmRepo.ChartVersions{
+				{Metadata: &helmChart.Metadata{Version: "109.0.1+up1.0.0"}},
+				{Metadata: &helmChart.Metadata{Version: "109.0.1+up2.0.0"}},
+				{Metadata: &helmChart.Metadata{Version: "109.0.1+up1.5.0"}},
+			},
+			expected: []string{
+				"109.0.1+up2.0.0", // chart version 2.0.0 is newest
+				"109.0.1+up1.5.0",
+				"109.0.1+up1.0.0",
 			},
 		},
 	}


### PR DESCRIPTION
Issue: https://github.com/rancher/ecm-distro-tools/issues/909

## Summary
- Fix version comparison logic to handle cases where multiple chart versions share the same upstream version (e.g., `109.0.1+up0.10.4-rc.1` and `109.0.1+up0.10.1-rc.2`)
- Split versions on `+up` delimiter and compare upstream and chart versions separately using semver, ensuring correct descending order when upstream versions match
- Add comprehensive test coverage with 12 test cases including edge cases for plain versions, mixed formats, prerelease hierarchies, and boundary values

## Tests
- Added test case for issue #909 (same upstream, different chart versions)
- Added 6 edge case tests: versions without +up format, mixed +up and plain versions, same upstream/chart with different prerelease types, large version numbers, zero versions, and chart version major changes