### PR TITLE
fix(git): make upstream remote detection protocol-agnostic

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -353,17 +353,28 @@ func (g *Git) ResetHEAD() error {
 	return exec.Command("git", "-C", g.Dir, "reset", "HEAD").Run()
 }
 
+// normalizeGitURL removes .git suffix for flexible URL matching
+func normalizeGitURL(url string) string {
+	return strings.TrimSuffix(url, ".git")
+}
+
 func (g *Git) getUpstreamRemote() (string, error) {
-	upstreamRemote := g.Remotes["https://github.com/rancher/charts"]
-	if upstreamRemote == "" {
-		upstreamRemote = g.Remotes["git@github.com:rancher/charts.git"]
+	// Pattern matching for rancher/charts upstream (protocol-agnostic)
+	patterns := []string{
+		"github.com/rancher/charts",
+		"github.com:rancher/charts",
 	}
 
-	if upstreamRemote == "" {
-		return "", errors.New("upstream remote not configured")
+	for remoteURL, remoteName := range g.Remotes {
+		normalized := normalizeGitURL(remoteURL)
+		for _, pattern := range patterns {
+			if strings.Contains(normalized, pattern) {
+				return remoteName, nil
+			}
+		}
 	}
 
-	return upstreamRemote, nil
+	return "", errors.New("upstream remote not configured")
 }
 
 // Status prints the status of the git repository

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -1,0 +1,109 @@
+package git
+
+import (
+	"testing"
+)
+
+func TestGetUpstreamRemote(t *testing.T) {
+	tests := []struct {
+		name        string
+		remotes     map[string]string
+		expectName  string
+		expectError bool
+	}{
+		{
+			name: "HTTPS with .git suffix",
+			remotes: map[string]string{
+				"https://github.com/rancher/charts.git": "upstream",
+			},
+			expectName:  "upstream",
+			expectError: false,
+		},
+		{
+			name: "HTTPS without .git suffix",
+			remotes: map[string]string{
+				"https://github.com/rancher/charts": "upstream",
+			},
+			expectName:  "upstream",
+			expectError: false,
+		},
+		{
+			name: "SSH with .git suffix",
+			remotes: map[string]string{
+				"git@github.com:rancher/charts.git": "upstream",
+			},
+			expectName:  "upstream",
+			expectError: false,
+		},
+		{
+			name: "SSH without .git suffix",
+			remotes: map[string]string{
+				"git@github.com:rancher/charts": "upstream",
+			},
+			expectName:  "upstream",
+			expectError: false,
+		},
+		{
+			name: "Multiple remotes with upstream",
+			remotes: map[string]string{
+				"https://github.com/fork/charts.git":    "origin",
+				"https://github.com/rancher/charts.git": "upstream",
+			},
+			expectName:  "upstream",
+			expectError: false,
+		},
+		{
+			name: "Remote named 'origin' but correct URL",
+			remotes: map[string]string{
+				"git@github.com:rancher/charts.git": "origin",
+			},
+			expectName:  "origin",
+			expectError: false,
+		},
+		{
+			name: "Wrong repository",
+			remotes: map[string]string{
+				"https://github.com/rancher/other-repo.git": "upstream",
+			},
+			expectName:  "",
+			expectError: true,
+		},
+		{
+			name:        "No remotes",
+			remotes:     map[string]string{},
+			expectName:  "",
+			expectError: true,
+		},
+		{
+			name: "Fork of rancher/charts",
+			remotes: map[string]string{
+				"https://github.com/myuser/rancher/charts.git": "origin",
+			},
+			expectName:  "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &Git{
+				Remotes: tt.remotes,
+			}
+
+			remoteName, err := g.getUpstreamRemote()
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if remoteName != tt.expectName {
+					t.Errorf("expected remote name %q, got %q", tt.expectName, remoteName)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded URL lookups with pattern matching that works regardless of protocol (https:// vs git@) or .git suffix
- Search all remotes for rancher/charts pattern instead of checking specific URL formats
- Add normalizeGitURL helper to strip .git suffix for flexible matching

## Tests
- Added 8 test cases covering HTTPS/SSH protocols, .git suffix variations, multiple remotes, and edge cases