### PR TITLE
refactor(validate): icons bypass for removed charts 

### DIFF
--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -11,9 +11,9 @@ import (
 )
 
 // LoadChartYaml will load a given chart.yaml file for the target chart and version
-func LoadChartYaml(rootFs billy.Filesystem, chart, chartVersion string) (*helmChart.Metadata, error) {
+func LoadChartYaml(rootFs billy.Filesystem, chart, version string) (*helmChart.Metadata, error) {
 	// Get Chart.yaml path and load it
-	chartYamlPath := path.RepositoryChartsDir + "/" + chart + "/" + chartVersion + "/Chart.yaml"
+	chartYamlPath := path.RepositoryChartsDir + "/" + chart + "/" + version + "/Chart.yaml"
 	absChartPath := filesystem.GetAbsPath(rootFs, chartYamlPath)
 
 	// Load Chart.yaml file

--- a/pkg/validate/icons.go
+++ b/pkg/validate/icons.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/charts-build-scripts/pkg/helm"
 	"github.com/rancher/charts-build-scripts/pkg/logger"
 	"github.com/rancher/charts-build-scripts/pkg/options"
+	"github.com/rancher/charts-build-scripts/pkg/path"
 )
 
 // Icons checks that every chart listed in release.yaml has a local icon present
@@ -64,6 +65,15 @@ func IsIconException(chart string) bool {
 // loadAndCheckIconPrefix loads Chart.yaml for the given chart version and verifies
 // that the icon field uses a local file:// path that actually exists on the filesystem.
 func loadAndCheckIconPrefix(ctx context.Context, rootFs billy.Filesystem, chart string, chartVersion string) error {
+	exists, err := filesystem.PathExists(ctx, rootFs, path.RepositoryChartsDir+"/"+chart+"/"+chartVersion+"/Chart.yaml")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		logger.Log(ctx, slog.LevelWarn, "chart was removed, skipping....", slog.String("chart", chart), slog.String("version", chartVersion))
+		return nil
+	}
+
 	metadata, err := helm.LoadChartYaml(rootFs, chart, chartVersion)
 	if err != nil {
 		return err

--- a/pkg/validate/icons_test.go
+++ b/pkg/validate/icons_test.go
@@ -65,12 +65,6 @@ func Test_loadAndCheckIconPrefix(t *testing.T) {
 			createIcon:  false,
 			expectedErr: "icon path is a file:// prefix, but the icon does not exist",
 		},
-		{
-			name:        "#4 - Chart.yaml does not exist",
-			createChart: false,
-			createIcon:  false,
-			expectedErr: "could not load",
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Related to: https://github.com/rancher/ecm-distro-tools/issues/946

make remove fails when chart is removed but still has an icon