### PR TITLE
fix: Gracefully ignore blocklist outside expected Rancher repos

### DIFF
--- a/pkg/config/blocklist.go
+++ b/pkg/config/blocklist.go
@@ -3,9 +3,11 @@ package config
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"slices"
 
 	"github.com/rancher/charts-build-scripts/pkg/git"
+	"github.com/rancher/charts-build-scripts/pkg/logger"
 	"github.com/rancher/charts-build-scripts/pkg/path"
 	"gopkg.in/yaml.v3"
 )
@@ -23,6 +25,12 @@ func LoadBlockList(ctx context.Context) (*Blocklist, error) {
 
 	// Fetch latest automation-core branch
 	if err := repo.FetchBranch(path.AutoCoreBranch); err != nil {
+		// If this repo doesn't have a rancher/charts upstream remote, return empty blocklist
+		if errors.Is(err, git.ErrNoUpstreamRemote) {
+			logger.Log(ctx, slog.LevelWarn, "blocklist unavailable in non-rancher/charts repo, using empty blocklist",
+				slog.String("branch", path.AutoCoreBranch))
+			return &Blocklist{Charts: make(map[string][]string)}, nil
+		}
 		return nil, errors.New("load blocklist fetch branch: " + err.Error())
 	}
 

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -15,6 +15,10 @@ import (
 	"github.com/rancher/charts-build-scripts/pkg/logger"
 )
 
+// ErrNoUpstreamRemote is returned when the repository doesn't have a configured
+// upstream remote matching rancher/charts or rancher/prime-charts patterns
+var ErrNoUpstreamRemote = errors.New("upstream remote not configured")
+
 // Git struct holds necessary data to work with the current git repository
 type Git struct {
 	Dir     string
@@ -376,7 +380,7 @@ func (g *Git) getUpstreamRemote() (string, error) {
 		}
 	}
 
-	return "", errors.New("upstream remote not configured")
+	return "", ErrNoUpstreamRemote
 }
 
 // Status prints the status of the git repository


### PR DESCRIPTION
The new `blocklist` feature for index generation is causing errors in the ORBS team repo where the `automation-core` branch does not exist. As a "simple" fix we can emit a custom error from `getUpstreamRemote` where the error ORBS repo triggers comes from.

Then subsequently inside of `LoadBlockList` we can use `errors.Is` to verify that this is the error we got so that the blocklist returns empty instead of an error which will gracefully fallback to the behavior that existed before `blocklist` was added.