### PR TITLE
Trivy automation

### DIFF
--- a/main.go
+++ b/main.go
@@ -1060,6 +1060,7 @@ func validateImageVersions(_ *cli.Context) {
 func checkChartCVEs(_ *cli.Context) {
 	ctx := context.Background()
 	getRepoRoot()
+	RepoRoot = "/Users/dsouza/dev/diogo-fork-charts/charts"
 	report, err := registries.CheckChartCVEs(ctx, RepoRoot, CurrentChart, ChartVersion)
 	if err != nil {
 		logger.Fatal(ctx, fmt.Errorf("check-chart-cves failed: %w", err).Error())

--- a/main.go
+++ b/main.go
@@ -586,6 +586,12 @@ func main() {
 			Action: validateImageVersions,
 			Flags:  []cli.Flag{chartFlag, chartVersionFlag},
 		},
+		{
+			Name:   "check-chart-cves",
+			Usage:  "Check all chart images for CVEs and compare it with the last version with the same major",
+			Action: checkChartCVEs,
+			Flags:  []cli.Flag{chartFlag, chartVersionFlag},
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -1045,6 +1051,18 @@ func validateImageVersions(_ *cli.Context) {
 	report, err := registries.ValidateImageVersions(ctx, RepoRoot, CurrentChart, ChartVersion)
 	if err != nil {
 		logger.Fatal(ctx, fmt.Errorf("validate-image-versions failed: %w", err).Error())
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
+		logger.Fatal(ctx, fmt.Errorf("encoding report: %w", err).Error())
+	}
+}
+
+func checkChartCVEs(_ *cli.Context) {
+	ctx := context.Background()
+	getRepoRoot()
+	report, err := registries.CheckChartCVEs(ctx, RepoRoot, CurrentChart, ChartVersion)
+	if err != nil {
+		logger.Fatal(ctx, fmt.Errorf("check-chart-cves failed: %w", err).Error())
 	}
 	if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
 		logger.Fatal(ctx, fmt.Errorf("encoding report: %w", err).Error())

--- a/main.go
+++ b/main.go
@@ -814,6 +814,7 @@ func getRepoRoot() {
 	RepoRoot = os.Getenv("DEV_REPO_ROOT")
 	if RepoRoot != "" {
 		logger.Log(ctx, slog.LevelDebug, "using customized repo root: ", slog.String("repoRoot", RepoRoot))
+		return
 	}
 
 	repoRoot, err := os.Getwd()
@@ -1060,7 +1061,6 @@ func validateImageVersions(_ *cli.Context) {
 func checkChartCVEs(_ *cli.Context) {
 	ctx := context.Background()
 	getRepoRoot()
-	RepoRoot = "/Users/dsouza/dev/diogo-fork-charts/charts"
 	report, err := registries.CheckChartCVEs(ctx, RepoRoot, CurrentChart, ChartVersion)
 	if err != nil {
 		logger.Fatal(ctx, fmt.Errorf("check-chart-cves failed: %w", err).Error())

--- a/pkg/registries/cveCheck.go
+++ b/pkg/registries/cveCheck.go
@@ -5,6 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+
+	"github.com/Masterminds/semver"
+	"github.com/rancher/charts-build-scripts/pkg/filesystem"
+	"github.com/rancher/charts-build-scripts/pkg/helm"
 )
 
 // SeverityCounts holds the number of CVEs found for each severity level.
@@ -53,7 +57,6 @@ func CheckChartCVEs(ctx context.Context, repoRoot, chart, version string) (CVERe
 	}
 	report.CVECounts = counts
 	report.Images = images
-
 	return report, nil
 }
 
@@ -61,7 +64,7 @@ func CheckChartCVEs(ctx context.Context, repoRoot, chart, version string) (CVERe
 // returning the aggregated severity counts and the per-image breakdown.
 func scanChartVersion(ctx context.Context, repoRoot, chart, version string) (SeverityCounts, []ImageCVEResult, error) {
 	var total SeverityCounts
-	images := []ImageCVEResult{}
+	var images []ImageCVEResult
 
 	chartImages, err := collectChartImages(ctx, repoRoot, chart, version)
 	if err != nil {
@@ -84,6 +87,34 @@ func scanChartVersion(ctx context.Context, repoRoot, chart, version string) (Sev
 	}
 
 	return total, images, nil
+}
+
+// findPreviousSameMajorVersion returns the highest released version of chart that is lower
+// than version and shares its major version, if any.
+// Helm's LoadIndexFile sorts the index.yaml in descending order.
+func findPreviousSameMajorVersion(ctx context.Context, repoRoot, chart, version string) (string, bool, error) {
+	index, err := helm.OpenIndexYaml(ctx, filesystem.GetFilesystem(repoRoot))
+	if err != nil {
+		return "", false, fmt.Errorf("opening index.yaml: %w", err)
+	}
+
+	currentVer, err := semver.NewVersion(version)
+	if err != nil {
+		return "", false, nil
+	}
+
+	for _, chartVersion := range index.Entries[chart] {
+		v, err := semver.NewVersion(chartVersion.Version)
+		if err != nil || v.Prerelease() != "" || !v.LessThan(currentVer) {
+			continue
+		}
+		if v.Major() != currentVer.Major() {
+			return "", false, nil
+		}
+		return chartVersion.Version, true, nil
+	}
+
+	return "", false, nil
 }
 
 // scanImage runs trivy against repository:tag and returns its CVE counts by severity.

--- a/pkg/registries/cveCheck.go
+++ b/pkg/registries/cveCheck.go
@@ -2,6 +2,9 @@ package registries
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
 )
 
 // SeverityCounts holds the number of CVEs found for each severity level.
@@ -30,9 +33,104 @@ type CVEReport struct {
 	Delta           *SeverityCounts  `json:"delta,omitempty"`
 }
 
+// trivyReport represents a subset of Trivy's JSON output.
+type trivyReport struct {
+	Results []struct {
+		Vulnerabilities []struct {
+			Severity string `json:"Severity"`
+		} `json:"Vulnerabilities"`
+	} `json:"Results"`
+}
+
 // CheckChartCVEs scans every image used by chart/version with Trivy, and if a previous
 // released version with the same major exists, scans it too and reports the CVE delta.
 func CheckChartCVEs(ctx context.Context, repoRoot, chart, version string) (CVEReport, error) {
 	report := CVEReport{Chart: chart, Version: version}
+
+	counts, images, err := scanChartVersion(ctx, repoRoot, chart, version)
+	if err != nil {
+		return report, fmt.Errorf("scanning %s:%s: %w", chart, version, err)
+	}
+	report.CVECounts = counts
+	report.Images = images
+
 	return report, nil
+}
+
+// scanChartVersion collects every image used by chart/version and scans each one with trivy,
+// returning the aggregated severity counts and the per-image breakdown.
+func scanChartVersion(ctx context.Context, repoRoot, chart, version string) (SeverityCounts, []ImageCVEResult, error) {
+	var total SeverityCounts
+	images := []ImageCVEResult{}
+
+	chartImages, err := collectChartImages(ctx, repoRoot, chart, version)
+	if err != nil {
+		return total, nil, fmt.Errorf("collecting chart images: %w", err)
+	}
+
+	for repository, tags := range chartImages {
+		for _, tag := range tags {
+			counts, err := scanImage(ctx, repository, tag)
+			if err != nil {
+				return total, nil, fmt.Errorf("scanning %s:%s: %w", repository, tag, err)
+			}
+			images = append(images, ImageCVEResult{Repository: repository, Tag: tag, CVECounts: counts})
+			total.Critical += counts.Critical
+			total.High += counts.High
+			total.Medium += counts.Medium
+			total.Low += counts.Low
+			total.Unknown += counts.Unknown
+		}
+	}
+
+	return total, images, nil
+}
+
+// scanImage runs trivy against repository:tag and returns its CVE counts by severity.
+var scanImage = func(ctx context.Context, repository, tag string) (SeverityCounts, error) {
+	output, err := runTrivy(ctx, repository, tag)
+	if err != nil {
+		return SeverityCounts{}, err
+	}
+	return parseTrivyReport(output)
+}
+
+// runTrivy shells out to the trivy CLI and returns its raw JSON report for repository:tag.
+func runTrivy(ctx context.Context, repository, tag string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "trivy", "image", "--format", "json", "--quiet", fmt.Sprintf("%s:%s", repository, tag))
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("running trivy on %s:%s: %w", repository, tag, err)
+	}
+
+	return output, nil
+}
+
+// parseTrivyReport tallies CVE counts by severity from trivy's JSON output.
+func parseTrivyReport(data []byte) (SeverityCounts, error) {
+	var report trivyReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		return SeverityCounts{}, fmt.Errorf("parsing trivy report: %w", err)
+	}
+
+	var counts SeverityCounts
+	for _, result := range report.Results {
+		for _, vuln := range result.Vulnerabilities {
+			switch vuln.Severity {
+			case "CRITICAL":
+				counts.Critical++
+			case "HIGH":
+				counts.High++
+			case "MEDIUM":
+				counts.Medium++
+			case "LOW":
+				counts.Low++
+			case "UNKNOWN":
+				counts.Unknown++
+			}
+		}
+	}
+
+	return counts, nil
 }

--- a/pkg/registries/cveCheck.go
+++ b/pkg/registries/cveCheck.go
@@ -1,0 +1,38 @@
+package registries
+
+import (
+	"context"
+)
+
+// SeverityCounts holds the number of CVEs found for each severity level.
+type SeverityCounts struct {
+	Critical int64 `json:"critical"`
+	High     int64 `json:"high"`
+	Medium   int64 `json:"medium"`
+	Low      int64 `json:"low"`
+	Unknown  int64 `json:"unknown"`
+}
+
+// ImageCVEResult holds the CVE counts found for a single image:tag.
+type ImageCVEResult struct {
+	Repository string `json:"repository"`
+	Tag        string `json:"tag"`
+	CVECounts  SeverityCounts
+}
+
+// CVEReport is the top-level output of CheckChartCVEs.
+type CVEReport struct {
+	Chart           string `json:"chart"`
+	Version         string `json:"version"`
+	CVECounts       SeverityCounts
+	Images          []ImageCVEResult `json:"images"`
+	PreviousVersion string           `json:"previousVersion,omitempty"`
+	Delta           *SeverityCounts  `json:"delta,omitempty"`
+}
+
+// CheckChartCVEs scans every image used by chart/version with Trivy, and if a previous
+// released version with the same major exists, scans it too and reports the CVE delta.
+func CheckChartCVEs(ctx context.Context, repoRoot, chart, version string) (CVEReport, error) {
+	report := CVEReport{Chart: chart, Version: version}
+	return report, nil
+}

--- a/pkg/registries/cveCheck.go
+++ b/pkg/registries/cveCheck.go
@@ -57,6 +57,28 @@ func CheckChartCVEs(ctx context.Context, repoRoot, chart, version string) (CVERe
 	}
 	report.CVECounts = counts
 	report.Images = images
+
+	previousVersion, found, err := findPreviousSameMajorVersion(ctx, repoRoot, chart, version)
+	if err != nil {
+		return report, fmt.Errorf("finding previous version: %w", err)
+	}
+	if !found {
+		return report, nil
+	}
+	report.PreviousVersion = previousVersion
+
+	previousCounts, _, err := scanChartVersion(ctx, repoRoot, chart, previousVersion)
+	if err != nil {
+		return report, fmt.Errorf("scanning %s:%s: %w", chart, previousVersion, err)
+	}
+	report.Delta = &SeverityCounts{
+		Critical: counts.Critical - previousCounts.Critical,
+		High:     counts.High - previousCounts.High,
+		Medium:   counts.Medium - previousCounts.Medium,
+		Low:      counts.Low - previousCounts.Low,
+		Unknown:  counts.Unknown - previousCounts.Unknown,
+	}
+
 	return report, nil
 }
 

--- a/pkg/registries/cveCheck.go
+++ b/pkg/registries/cveCheck.go
@@ -22,16 +22,16 @@ type SeverityCounts struct {
 
 // ImageCVEResult holds the CVE counts found for a single image:tag.
 type ImageCVEResult struct {
-	Repository string `json:"repository"`
-	Tag        string `json:"tag"`
-	CVECounts  SeverityCounts
+	Repository string         `json:"repository"`
+	Tag        string         `json:"tag"`
+	CVECounts  SeverityCounts `json:"CVEs"`
 }
 
 // CVEReport is the top-level output of CheckChartCVEs.
 type CVEReport struct {
-	Chart           string `json:"chart"`
-	Version         string `json:"version"`
-	CVECounts       SeverityCounts
+	Chart           string           `json:"chart"`
+	Version         string           `json:"version"`
+	CVECounts       SeverityCounts   `json:"CVEs"`
 	Images          []ImageCVEResult `json:"images"`
 	PreviousVersion string           `json:"previousVersion,omitempty"`
 	Delta           *SeverityCounts  `json:"delta,omitempty"`

--- a/pkg/registries/cveCheck.go
+++ b/pkg/registries/cveCheck.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
 	"github.com/rancher/charts-build-scripts/pkg/helm"
 )

--- a/pkg/registries/cveCheck_test.go
+++ b/pkg/registries/cveCheck_test.go
@@ -1,9 +1,207 @@
 package registries
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckChartCVEs(t *testing.T) {
+	ctx := context.Background()
 
+	t.Run("delta against previous version", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		writeValuesYaml(t, repoRoot, "monitoring", "103.1.0+up45.0.1", `
+image:
+  repository: rancher/prometheus
+  tag: v2.47.0
+`)
+		writeValuesYaml(t, repoRoot, "monitoring", "103.0.0+up45.0.0", `
+image:
+  repository: rancher/prometheus
+  tag: v2.46.0
+`)
+		writeIndexYaml(t, repoRoot, "monitoring", "103.1.0+up45.0.1", "103.0.0+up45.0.0")
+
+		orig := scanImage
+		defer func() { scanImage = orig }()
+		scanImage = func(_ context.Context, repository, tag string) (SeverityCounts, error) {
+			switch fmt.Sprintf("%s:%s", repository, tag) {
+			case "rancher/prometheus:v2.47.0":
+				return SeverityCounts{Critical: 1, High: 2, Medium: 3, Low: 4, Unknown: 1}, nil
+			case "rancher/prometheus:v2.46.0":
+				return SeverityCounts{Critical: 3, High: 1, Medium: 3, Low: 2, Unknown: 2}, nil
+			}
+			return SeverityCounts{}, fmt.Errorf("unexpected image %s:%s", repository, tag)
+		}
+
+		report, err := CheckChartCVEs(ctx, repoRoot, "monitoring", "103.1.0+up45.0.1")
+		require.NoError(t, err)
+
+		assert.Equal(t, SeverityCounts{Critical: 1, High: 2, Medium: 3, Low: 4, Unknown: 1}, report.CVECounts)
+		require.Len(t, report.Images, 1)
+		assert.Equal(t, "rancher/prometheus", report.Images[0].Repository)
+		assert.Equal(t, "v2.47.0", report.Images[0].Tag)
+
+		assert.Equal(t, "103.0.0+up45.0.0", report.PreviousVersion)
+		require.NotNil(t, report.Delta)
+		assert.Equal(t, SeverityCounts{Critical: -2, High: 1, Medium: 0, Low: 2, Unknown: -1}, *report.Delta)
+	})
+
+	t.Run("no previous version", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		writeValuesYaml(t, repoRoot, "monitoring", "103.0.0+up45.0.0", `
+image:
+  repository: rancher/prometheus
+  tag: v2.46.0
+`)
+		writeIndexYaml(t, repoRoot, "monitoring", "103.0.0+up45.0.0")
+
+		orig := scanImage
+		defer func() { scanImage = orig }()
+		scanImage = func(_ context.Context, _, _ string) (SeverityCounts, error) {
+			return SeverityCounts{Critical: 1}, nil
+		}
+
+		report, err := CheckChartCVEs(ctx, repoRoot, "monitoring", "103.0.0+up45.0.0")
+		require.NoError(t, err)
+
+		assert.Equal(t, SeverityCounts{Critical: 1}, report.CVECounts)
+		assert.Empty(t, report.PreviousVersion)
+		assert.Nil(t, report.Delta)
+	})
+}
+
+func TestFindPreviousSameMajorVersion(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		chart     string
+		version   string
+		want      string
+		wantFound bool
+	}{
+		{
+			name:      "picks previous patch",
+			chart:     "monitoring",
+			version:   "103.1.0+up45.0.1",
+			want:      "103.0.0+up45.0.0",
+			wantFound: true,
+		},
+		{
+			name:      "version not yet in index",
+			chart:     "monitoring",
+			version:   "103.2.0+up45.0.2",
+			want:      "103.1.0+up45.0.1",
+			wantFound: true,
+		},
+		{
+			name:      "major bump has nothing to compare against",
+			chart:     "monitoring",
+			version:   "104.0.0+up46.0.0",
+			wantFound: false,
+		},
+		{
+			name:      "prerelease in between is skipped",
+			chart:     "rancher-istio",
+			version:   "103.1.0",
+			want:      "103.0.0",
+			wantFound: true,
+		},
+		{
+			name:      "chart not tracked in index",
+			chart:     "unknown-chart",
+			version:   "1.0.0",
+			wantFound: false,
+		},
+	}
+
+	repoRoot := t.TempDir()
+	writeIndexYaml(t, repoRoot, "monitoring", "103.1.0+up45.0.1", "103.0.0+up45.0.0", "102.0.0+up44.0.0")
+	writeIndexYaml(t, repoRoot, "rancher-istio", "103.1.0", "103.1.0-rc.1", "103.0.0")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, found, err := findPreviousSameMajorVersion(ctx, repoRoot, tt.chart, tt.version)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFound, found)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseTrivyReport(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		want    SeverityCounts
+		wantErr bool
+	}{
+		{
+			name: "counts every severity",
+			json: `{"Results": [{"Vulnerabilities": [
+				{"Severity": "CRITICAL"},
+				{"Severity": "HIGH"},
+				{"Severity": "HIGH"},
+				{"Severity": "MEDIUM"},
+				{"Severity": "LOW"},
+				{"Severity": "UNKNOWN"}
+			]}]}`,
+			want: SeverityCounts{Critical: 1, High: 2, Medium: 1, Low: 1, Unknown: 1},
+		},
+		{
+			name: "aggregates across results",
+			json: `{"Results": [
+				{"Vulnerabilities": [{"Severity": "CRITICAL"}]},
+				{"Vulnerabilities": [{"Severity": "CRITICAL"}]}
+			]}`,
+			want: SeverityCounts{Critical: 2},
+		},
+		{
+			name: "no vulnerabilities",
+			json: `{"Results": []}`,
+			want: SeverityCounts{},
+		},
+		{
+			name:    "malformed json",
+			json:    `not json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTrivyReport([]byte(tt.json))
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// writeIndexYaml appends a chart's versions to <repoRoot>/index.yaml, creating it on first use.
+func writeIndexYaml(t *testing.T, repoRoot, chart string, versions ...string) {
+	t.Helper()
+
+	block := fmt.Sprintf("  %s:\n", chart)
+	for _, version := range versions {
+		block += fmt.Sprintf("  - apiVersion: v2\n    name: %s\n    version: %q\n", chart, version)
+	}
+
+	path := filepath.Join(repoRoot, "index.yaml")
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		require.NoError(t, os.WriteFile(path, []byte("apiVersion: v1\nentries:\n"+block), 0644))
+		return
+	}
+	require.NoError(t, os.WriteFile(path, append(existing, []byte(block)...), 0644))
 }

--- a/pkg/registries/cveCheck_test.go
+++ b/pkg/registries/cveCheck_test.go
@@ -1,0 +1,9 @@
+package registries
+
+import (
+	"testing"
+)
+
+func TestCheckChartCVEs(t *testing.T) {
+
+}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/56141

Creates a new `check-chart-cves` that receives a chart and a version as parameters.

1. Gets all the images present in the chart and gets all the CVEs in them
2. Gets the previous version of that chart and gets all the CVEs in the images used by it
3. Returns the amount of CVEs in the new version and the delta from the previous version

Example of output:
````
{
  "chart": "rancher-backup",
  "version": "109.0.7+up10.0.8-rc.4",
  "CVEs": {
    "critical": 0,
    "high": 20,
    "medium": 22,
    "low": 0,
    "unknown": 15
  },
  "images": [
    {
      "repository": "rancher/kuberlr-kubectl",
      "tag": "v7.1.1",
      "CVEs": {
        "critical": 0,
        "high": 20,
        "medium": 22,
        "low": 0,
        "unknown": 12
      }
    },
    {
      "repository": "rancher/backup-restore-operator",
      "tag": "v10.0.8-rc.4",
      "CVEs": {
        "critical": 0,
        "high": 0,
        "medium": 0,
        "low": 0,
        "unknown": 3
      }
    }
  ],
  "previousVersion": "109.0.6+up10.0.7",
  "delta": {
    "critical": -1,
    "high": -55,
    "medium": -50,
    "low": -5,
    "unknown": 0
  }
}
````
 