### PR TITLE
feat(registries): skip blocklisted chart versions in check-images

### DIFF
--- a/pkg/registries/assets.go
+++ b/pkg/registries/assets.go
@@ -3,9 +3,11 @@ package registries
 import (
 	"context"
 	"log/slog"
+	"path/filepath"
 	"slices"
 	"strings"
 
+	"github.com/rancher/charts-build-scripts/pkg/config"
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
 	"github.com/rancher/charts-build-scripts/pkg/logger"
 )
@@ -27,6 +29,15 @@ var createAssetValuesRepoTagMap = func(ctx context.Context) (map[string][]string
 	if err != nil {
 		return nil, err
 	}
+
+	// load blocklist to skip checking images for blocklisted chart versions
+	blocklist, err := config.LoadBlockList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// filter out blocklisted chart versions
+	assetsTgzs = filterBlocklistedAssets(ctx, assetsTgzs, blocklist)
 
 	// decode .tgz values.yaml files into-memory
 	logger.Log(ctx, slog.LevelInfo, "decoding .tgz(values.yaml) in-memory")
@@ -63,6 +74,43 @@ var createAssetValuesRepoTagMap = func(ctx context.Context) (map[string][]string
 	}
 
 	return repoTagMap, nil
+}
+
+// filterBlocklistedAssets removes blocklisted chart versions from tgz list.
+// Expected tgz path format: assets/{chart}/{chart}-{version}.tgz
+func filterBlocklistedAssets(ctx context.Context, tgzPaths []string, blocklist *config.Blocklist) []string {
+	filtered := make([]string, 0, len(tgzPaths))
+
+	for _, tgzPath := range tgzPaths {
+		// extract chart name and version from path
+		// assets/rancher-monitoring/rancher-monitoring-109.0.1+up80.9.1.tgz
+		base := filepath.Base(tgzPath)
+		chartDir := filepath.Base(filepath.Dir(tgzPath))
+
+		// remove .tgz extension
+		nameVersion := strings.TrimSuffix(base, ".tgz")
+
+		// remove chart name prefix to get version
+		// rancher-monitoring-109.0.1+up80.9.1 -> 109.0.1+up80.9.1
+		version := strings.TrimPrefix(nameVersion, chartDir+"-")
+
+		if blocklist.IsBlocked(chartDir, version) {
+			logger.Log(ctx, slog.LevelWarn, "skipping blocklisted chart version",
+				slog.String("chart", chartDir),
+				slog.String("version", version),
+				slog.String("path", tgzPath))
+			continue
+		}
+
+		filtered = append(filtered, tgzPath)
+	}
+
+	logger.Log(ctx, slog.LevelInfo, "filtered blocklisted assets",
+		slog.Int("total", len(tgzPaths)),
+		slog.Int("filtered", len(filtered)),
+		slog.Int("skipped", len(tgzPaths)-len(filtered)))
+
+	return filtered
 }
 
 // traverseRepoTags will traverse across 'data' whihc should be nesteds map[string]interface and []interface.

--- a/pkg/registries/assets_test.go
+++ b/pkg/registries/assets_test.go
@@ -1,0 +1,42 @@
+package registries
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rancher/charts-build-scripts/pkg/config"
+)
+
+func TestFilterBlocklistedAssets(t *testing.T) {
+	ctx := context.Background()
+
+	tgzPaths := []string{
+		"assets/rancher-monitoring/rancher-monitoring-109.0.1+up80.9.1.tgz",
+		"assets/rancher-monitoring/rancher-monitoring-109.0.2+up80.9.1-rancher.8.tgz",
+		"assets/rancher-monitoring/rancher-monitoring-109.0.3+up80.9.2.tgz",
+	}
+
+	blocklist := &config.Blocklist{
+		Charts: map[string][]string{
+			"rancher-monitoring": {"109.0.2+up80.9.1-rancher.8"},
+		},
+	}
+
+	filtered := filterBlocklistedAssets(ctx, tgzPaths, blocklist)
+
+	expectedCount := 2
+	if len(filtered) != expectedCount {
+		t.Fatalf("expected %d filtered assets, got %d", expectedCount, len(filtered))
+	}
+
+	expected := []string{
+		"assets/rancher-monitoring/rancher-monitoring-109.0.1+up80.9.1.tgz",
+		"assets/rancher-monitoring/rancher-monitoring-109.0.3+up80.9.2.tgz",
+	}
+
+	for i, path := range expected {
+		if filtered[i] != path {
+			t.Errorf("expected filtered[%d] = %s, got %s", i, path, filtered[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Load blocklist from automation-core before image tag validation
- Filter blocklisted chart versions to prevent check-images failure when upstream image repositories are unavailable

## Tests
- Unit test validates filtering logic with 3 chart versions, 1 blocklisted, 2 passing through