### PR TITLE
fix(oci-dependency-resolution): Support OCI resolution and empty repository for chart dependencies.

### DIFF
--- a/pkg/charts/dependencies.go
+++ b/pkg/charts/dependencies.go
@@ -20,6 +20,7 @@ import (
 	helmLoader "helm.sh/helm/v3/pkg/chart/loader"
 	helmCLI "helm.sh/helm/v3/pkg/cli"
 	helmGetter "helm.sh/helm/v3/pkg/getter"
+	helmRegistry "helm.sh/helm/v3/pkg/registry"
 	helmRepo "helm.sh/helm/v3/pkg/repo"
 	"sigs.k8s.io/yaml"
 )
@@ -113,6 +114,30 @@ func PrepareDependencies(ctx context.Context, rootFs, pkgFs billy.Filesystem, ma
 	}
 
 	return UpdateHelmMetadataWithDependencies(ctx, pkgFs, mainHelmChartPath, dependencyMap)
+}
+
+// resolveDependencyURL resolves the download URL for a single chart dependency listed in Chart.lock.
+//
+// OCI-based chart repositories do not serve an index.yaml the way classic HTTP(S) chart repositories
+// do, so helmRepo.FindChartInRepoURL cannot be used to resolve them. For OCI repositories we instead
+// build the fully-qualified "oci://host/path/chart:version" reference directly;
+// GetUpstream/puller.Registry already knows how to pull that.
+func resolveDependencyURL(repository, name, version string) (string, error) {
+	if helmRegistry.IsOCI(repository) {
+		return fmt.Sprintf("%s/%s:%s", strings.TrimSuffix(repository, "/"), name, version), nil
+	}
+
+	// Acquire mutex to serialize Helm repository queries and prevent rate limiting
+	helmRepoFetchMutex.Lock()
+	defer helmRepoFetchMutex.Unlock()
+
+	return helmRepo.FindChartInRepoURL(
+		repository,
+		name,
+		version,
+		"", "", "",
+		helmGetter.All(&helmCLI.EnvSettings{}),
+	)
 }
 
 func getMainChartUpstreamOptions(ctx context.Context, pkgFs billy.Filesystem, gcRootDir string) (*options.UpstreamOptions, error) {
@@ -210,17 +235,7 @@ func LoadDependencies(ctx context.Context, pkgFs billy.Filesystem, mainHelmChart
 
 		logger.Log(ctx, slog.LevelDebug, "looking for dependency", slog.String("dependencyName", dependencyName), slog.String("repository", dependency.Repository))
 
-		// Acquire mutex to serialize Helm repository queries and prevent rate limiting
-		helmRepoFetchMutex.Lock()
-		dependencyURL, err := helmRepo.FindChartInRepoURL(
-			dependency.Repository,
-			dependencyName,
-			dependency.Version,
-			"", "", "",
-			helmGetter.All(&helmCLI.EnvSettings{}),
-		)
-		helmRepoFetchMutex.Unlock()
-
+		dependencyURL, err := resolveDependencyURL(dependency.Repository, dependencyName, dependency.Version)
 		if err != nil {
 			return fmt.Errorf("encountered error while trying to find the repository for dependency %s: %s", dependency.Name, err)
 		}

--- a/pkg/charts/dependencies.go
+++ b/pkg/charts/dependencies.go
@@ -185,9 +185,21 @@ func LoadDependencies(ctx context.Context, pkgFs billy.Filesystem, mainHelmChart
 			numChartsRemoved++
 		}
 	}
-	// Handle local chart archives first since version numbers don't make a difference
+	// Handle local chart archives first since version numbers don't make a difference.
+	// This covers two cases: dependencies whose repository is explicitly a "file://"
+	// path, and dependencies with an empty repository field.
+	//
+	// An empty repository means the chart isn't fetched from anywhere at all: it is
+	// expected to already live at charts/<name> within the parent chart itself
+	// (see https://helm.sh/docs/helm/helm_dependency/ - "local directory dependency")
 	for _, dependency := range mainChart.Metadata.Dependencies {
-		if !strings.HasPrefix(dependency.Repository, "file://") {
+		var relativeDependencyPath string
+		switch {
+		case strings.HasPrefix(dependency.Repository, "file://"):
+			relativeDependencyPath = strings.TrimPrefix(dependency.Repository, "file://")
+		case dependency.Repository == "":
+			relativeDependencyPath = filepath.Join("charts", dependency.Name)
+		default:
 			continue
 		}
 		dependencyName := dependency.Name
@@ -200,7 +212,7 @@ func LoadDependencies(ctx context.Context, pkgFs billy.Filesystem, mainHelmChart
 			logger.Log(ctx, slog.LevelInfo, "skipping dependency", slog.String("dependencyName", dependencyName))
 			continue
 		}
-		subdirectory := filepath.Join(filepath.Dir(strings.TrimPrefix(dependency.Repository, "file://")), dependencyName)
+		subdirectory := filepath.Join(filepath.Dir(relativeDependencyPath), dependencyName)
 		if mainChartUpstreamOpts.Subdirectory != nil {
 			subdirectory = filepath.Join(*mainChartUpstreamOpts.Subdirectory, subdirectory)
 		}
@@ -221,6 +233,11 @@ func LoadDependencies(ctx context.Context, pkgFs billy.Filesystem, mainHelmChart
 		return nil
 	}
 	for _, dependency := range mainChart.Lock.Dependencies {
+		if dependency.Repository == "" {
+			// An empty repository means this dependency is vendored locally under charts/<name> rather than fetched from a chart repository.
+			continue
+		}
+
 		dependencyName := dependency.Name
 		dependencyOptionsPath := filepath.Join(gcRootDir, path.GeneratedChangesDependenciesDir, dependencyName, path.DependencyOptionsFile)
 		// Check if dependency already exists

--- a/pkg/charts/dependencies_test.go
+++ b/pkg/charts/dependencies_test.go
@@ -1,0 +1,72 @@
+package charts
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_resolveDependencyURL(t *testing.T) {
+	t.Run("OCI repository", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			repository string
+			depName    string
+			version    string
+			expected   string
+		}{
+			{
+				name:       "bitnami postgresql",
+				repository: "oci://registry-1.docker.io/bitnamicharts",
+				depName:    "postgresql",
+				version:    "14.1.10",
+				expected:   "oci://registry-1.docker.io/bitnamicharts/postgresql:14.1.10",
+			},
+			{
+				name:       "trailing slash on repository is trimmed",
+				repository: "oci://registry-1.docker.io/bitnamicharts/",
+				depName:    "redis",
+				version:    "18.14.1",
+				expected:   "oci://registry-1.docker.io/bitnamicharts/redis:18.14.1",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got, err := resolveDependencyURL(tt.repository, tt.depName, tt.version)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, got)
+			})
+		}
+	})
+
+	t.Run("classic HTTP(S) repository still resolves via index.yaml", func(t *testing.T) {
+		mux := http.NewServeMux()
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		mux.HandleFunc("/index.yaml", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/yaml")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`apiVersion: v1
+entries:
+  mychart:
+    - name: mychart
+      version: 1.0.0
+      urls:
+        - mychart-1.0.0.tgz
+generated: "2023-01-01T00:00:00Z"
+`))
+		})
+
+		got, err := resolveDependencyURL(server.URL, "mychart", "1.0.0")
+		assert.NoError(t, err)
+		assert.Equal(t, server.URL+"/mychart-1.0.0.tgz", got)
+	})
+
+	t.Run("classic repository that cannot be reached returns an error", func(t *testing.T) {
+		_, err := resolveDependencyURL("http://127.0.0.1:0", "mychart", "1.0.0")
+		assert.Error(t, err)
+	})
+}

--- a/pkg/charts/dependencies_test.go
+++ b/pkg/charts/dependencies_test.go
@@ -1,11 +1,18 @@
 package charts
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/rancher/charts-build-scripts/pkg/filesystem"
+	"github.com/rancher/charts-build-scripts/pkg/options"
+	"github.com/rancher/charts-build-scripts/pkg/path"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_resolveDependencyURL(t *testing.T) {
@@ -69,4 +76,69 @@ generated: "2023-01-01T00:00:00Z"
 		_, err := resolveDependencyURL("http://127.0.0.1:0", "mychart", "1.0.0")
 		assert.Error(t, err)
 	})
+}
+
+// TestLoadDependencies_LocalPathDependency whose Chart.yaml/Chart.lock declare a
+// dependency with an empty "repository" field to indicate that the subchart is
+// already vendored locally under charts/<name>, rather than fetched from anywhere.
+func TestLoadDependencies_LocalPathDependency(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	pkgFs := filesystem.GetFilesystem(root)
+
+	packageVersion := 0
+	packageOpts := options.PackageOptions{
+		PackageVersion: &packageVersion,
+		MainChartOptions: options.ChartOptions{
+			WorkingDir: "charts",
+			UpstreamOptions: options.UpstreamOptions{
+				URL: "https://github.com/example/example-repo.git",
+			},
+		},
+	}
+	require.NoError(t, packageOpts.WriteToFile(ctx, pkgFs, path.PackageOptionsFile))
+
+	chartYaml := `apiVersion: v2
+name: test-chart
+version: 0.1.0
+type: application
+dependencies:
+  - name: shared
+    version: 1.0.0
+    repository: file://../shared
+  - name: bundled-sub-chart
+    version: 0.0.0
+    repository: ""
+`
+	chartLock := `dependencies:
+  - name: shared
+    repository: file://../shared
+    version: 1.0.0
+  - name: bundled-sub-chart
+    repository: ""
+    version: 0.0.0
+digest: sha256:0000000000000000000000000000000000000000000000000000000000000
+generated: "2024-01-01T00:00:00Z"
+`
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "charts"), os.ModePerm))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "charts", "Chart.yaml"), []byte(chartYaml), os.ModePerm))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "charts", "Chart.lock"), []byte(chartLock), os.ModePerm))
+
+	err := LoadDependencies(ctx, pkgFs, "charts", path.GeneratedChangesDir, map[string]bool{})
+	require.NoError(t, err)
+
+	// The "file://" dependency should be resolved relative to the main chart's upstream, unchanged.
+	sharedOpts, err := options.LoadChartOptionsFromFile(ctx, pkgFs, filepath.Join(path.GeneratedChangesDir, path.GeneratedChangesDependenciesDir, "shared", path.DependencyOptionsFile))
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/example/example-repo.git", sharedOpts.UpstreamOptions.URL)
+	require.NotNil(t, sharedOpts.UpstreamOptions.Subdirectory)
+	assert.Equal(t, "../shared", *sharedOpts.UpstreamOptions.Subdirectory)
+
+	// The empty-repository dependency should be treated as vendored under charts/<name>
+	// within the main chart itself, not sent to helm's repo index resolver.
+	subchartOpts, err := options.LoadChartOptionsFromFile(ctx, pkgFs, filepath.Join(path.GeneratedChangesDir, path.GeneratedChangesDependenciesDir, "bundled-sub-chart", path.DependencyOptionsFile))
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/example/example-repo.git", subchartOpts.UpstreamOptions.URL)
+	require.NotNil(t, subchartOpts.UpstreamOptions.Subdirectory)
+	assert.Equal(t, filepath.Join("charts", "bundled-sub-chart"), *subchartOpts.UpstreamOptions.Subdirectory)
 }


### PR DESCRIPTION
This PR addresses two shortcomings in the way which dependencies are currently resolved.
- lack of `oci://` support in Chart.lock
- incorrect resolution of `repository: ""` references, where only `file://` was previously supported.

#### OCI dependency
Each dependency entry in Chart.lock gets resolved via `repo.FindChartInRepoURL`, which only understands classic HTTP(S) chart repos which serve an index.yaml file. If a dependency is referenced via `oci://`, the current mechansim appends `/index.yaml` to the OCI repo URL which produces in invalid format preventing dependencies from being downloaded during the intial "prepare" stage.

```
09:26:03 ERR charts/package.go:48 encountered error while preparing chart path=charts error="encountered error while trying to prepare dependencies in charts: encountered error while trying to find the repository for dependency postgresql: looks like \"oci://registry-1.docker.io/bitnamicharts\" is not a valid chart repository or cannot be reached: failed to perform \"FetchReference\" on source: invalid reference"
09:26:03 ERR logger/log.go:36 encountered error while trying to prepare dependencies in charts: encountered error while trying to find the repository for dependency postgresql: looks like "oci://registry-1.docker.io/bitnamicharts" is not a valid chart repository or cannot be reached: failed to perform "FetchReference" on source: invalid reference
```

Added new wrapper function `resolveDependencyURL()`, which exits early if `helmRegistry.IsOCI()` is true returning the correctly formatted URL before /index.yaml can be appended.

I discovered this limitaton in the tooling when attempting to patch the infisical-standalone chart for my side project work.
- https://github.com/Infisical/infisical/blob/main/helm-charts/infisical-standalone-postgres/Chart.yaml#L23-L30

#### Empty Repository
If a chart has a dependency with `repository: ""` set, it means the dependency is already vendored alongside the main chart under `charts/<name>`, as such we don't need to perform any additional lookups to retrieve and download that source.

Previously, the tooling only supported `file://`. This brings closer alignment to how default helm functionality works.

```
10:23:43 ERR charts/package.go:48 encountered error while preparing chart path=charts error="encountered error while trying to prepare dependencies in charts: encountered error while trying to find the repository for dependency podlogs-crd: could not find protocol handler for: "
10:23:43 ERR logger/log.go:36 encountered error while trying to prepare dependencies in charts: encountered error while trying to find the repository for dependency podlogs-crd: could not find protocol handler for:
```

See: https://github.com/grafana/alloy-operator/blob/main/charts/alloy-operator/Chart.yaml#L23