### PR TITLE
Caching Git Configuration Requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          version: v1.62.2
+          version: v2.13.1
           only-new-issues: true
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          version: latest
+          version: v1.62.2
           install-mode: goinstall
           only-new-issues: true
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: v1.62.2
-          install-mode: goinstall
           only-new-issues: true
   build:
     runs-on: ubuntu-latest

--- a/pkg/change/apply.go
+++ b/pkg/change/apply.go
@@ -3,19 +3,17 @@ package change
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"path/filepath"
 	"strings"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
-	"github.com/rancher/charts-build-scripts/pkg/logger"
 	"github.com/rancher/charts-build-scripts/pkg/path"
 )
 
 // ApplyChanges applies the changes from the gcOverlayDirpath, gcExcludeDirpath, and gcPatchDirpath within gcDir to toDir within the package filesystem
 func ApplyChanges(ctx context.Context, fs billy.Filesystem, toDir, gcRootDir string) error {
-	logger.Log(ctx, slog.LevelInfo, "applying changes")
+
 	// gcRootDir should always end with path.GeneratedChangesDir
 	if !strings.HasSuffix(gcRootDir, path.GeneratedChangesDir) {
 		return fmt.Errorf("root directory for generated changes should end with %s, received: %s", path.GeneratedChangesDir, gcRootDir)
@@ -28,7 +26,6 @@ func ApplyChanges(ctx context.Context, fs billy.Filesystem, toDir, gcRootDir str
 			return nil
 		}
 
-		logger.Log(ctx, slog.LevelDebug, "applying patch", slog.String("path", patchPath))
 		return ApplyPatchDiff(ctx, fs, patchPath, toDir)
 	}
 
@@ -41,7 +38,6 @@ func ApplyChanges(ctx context.Context, fs billy.Filesystem, toDir, gcRootDir str
 			return err
 		}
 
-		logger.Log(ctx, slog.LevelDebug, "Adding", slog.String("filepath", filepath))
 		return filesystem.CopyFile(ctx, fs, overlayPath, filepath)
 	}
 
@@ -54,7 +50,6 @@ func ApplyChanges(ctx context.Context, fs billy.Filesystem, toDir, gcRootDir str
 			return err
 		}
 
-		logger.Log(ctx, slog.LevelDebug, "Removing", slog.String("filepath", filepath))
 		return filesystem.RemoveAll(fs, filepath)
 	}
 	exists, err := filesystem.PathExists(ctx, fs, chartsPatchDirpath)

--- a/pkg/change/diff.go
+++ b/pkg/change/diff.go
@@ -76,7 +76,6 @@ func GeneratePatchDiff(ctx context.Context, fs billy.Filesystem, patchPath, srcP
 
 // ApplyPatchDiff applies a patch file located at patchPath to the destDir on the filesystem
 func ApplyPatchDiff(ctx context.Context, fs billy.Filesystem, patchPath, destDir string) error {
-	logger.Log(ctx, slog.LevelInfo, "applying patches", slog.String("patchPath", patchPath), slog.String("destDir", destDir))
 
 	// TODO(aiyengar2): find a better library to actually generate and apply patches
 	// There doesn't seem to be any existing library at the moment that can work with unified patches
@@ -92,7 +91,7 @@ func ApplyPatchDiff(ctx context.Context, fs billy.Filesystem, patchPath, destDir
 	var buf bytes.Buffer
 	patchFile, err := fs.Open(patchPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("could not open %s - error: %w", patchPath, err)
 	}
 	defer patchFile.Close()
 

--- a/pkg/change/generate.go
+++ b/pkg/change/generate.go
@@ -19,7 +19,6 @@ const (
 
 // GenerateChanges generates the change between fromDir and toDir and places it in the appropriate directories within gcDir
 func GenerateChanges(ctx context.Context, fs billy.Filesystem, fromDir, toDir, gcRootDir string, replacePaths []string) error {
-	logger.Log(ctx, slog.LevelInfo, "generating changes", slog.String("GeneratedChangesDir", path.GeneratedChangesDir))
 
 	// gcRootDir should always end with path.GeneratedChangesDir
 	if !strings.HasSuffix(gcRootDir, path.GeneratedChangesDir) {
@@ -44,7 +43,6 @@ func GenerateChanges(ctx context.Context, fs billy.Filesystem, fromDir, toDir, g
 			return err
 		}
 
-		logger.Log(ctx, slog.LevelInfo, "overlay", slog.String("toPath", toPath))
 		return nil
 	}
 	generateExcludeFile := func(ctx context.Context, fs billy.Filesystem, fromPath string, isDir bool) error {
@@ -59,7 +57,6 @@ func GenerateChanges(ctx context.Context, fs billy.Filesystem, fromDir, toDir, g
 			return err
 		}
 
-		logger.Log(ctx, slog.LevelInfo, "exclude", slog.String("fromPath", fromPath))
 		return nil
 	}
 	generatePatchFile := func(ctx context.Context, fs billy.Filesystem, fromPath, toPath string, isDir bool) error {

--- a/pkg/charts/dependencies.go
+++ b/pkg/charts/dependencies.go
@@ -31,7 +31,6 @@ var helmRepoFetchMutex sync.Mutex
 
 // PrepareDependencies prepares all of the dependencies of a given chart and regenerates the requirements.yaml or Chart.yaml
 func PrepareDependencies(ctx context.Context, rootFs, pkgFs billy.Filesystem, mainHelmChartPath string, gcRootDir string, ignoreDependencies []string) error {
-	logger.Log(ctx, slog.LevelInfo, "loading dependencies")
 
 	ignoreDependencyMap := make(map[string]bool)
 	for _, dep := range ignoreDependencies {
@@ -275,7 +274,6 @@ func GetDependencyMap(ctx context.Context, pkgFs billy.Filesystem, gcRootDir str
 // UpdateHelmMetadataWithDependencies updates either the requirements.yaml or Chart.yaml for the dependencies provided
 // For each dependency in dependencies, it will replace the entry in the requirements.yaml / Chart.yaml with a URL pointing to the local chart archive
 func UpdateHelmMetadataWithDependencies(ctx context.Context, fs billy.Filesystem, mainHelmChartPath string, dependencyMap map[string]*Chart) error {
-	logger.Log(ctx, slog.LevelInfo, "updating chart metadata with dependencies")
 
 	// Check if Helm chart is valid
 	chart, err := helmLoader.Load(filesystem.GetAbsPath(fs, mainHelmChartPath))

--- a/pkg/config/blocklist.go
+++ b/pkg/config/blocklist.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"slices"
+	"sync"
 
 	"github.com/rancher/charts-build-scripts/pkg/git"
 	"github.com/rancher/charts-build-scripts/pkg/logger"
@@ -16,7 +17,20 @@ type Blocklist struct {
 	Charts map[string][]string
 }
 
+var (
+	cachedBlocklist *Blocklist
+	blocklistOnce   sync.Once
+	blocklistErr    error
+)
+
 func LoadBlockList(ctx context.Context) (*Blocklist, error) {
+	blocklistOnce.Do(func() {
+		cachedBlocklist, blocklistErr = fetchBlocklistFromRemote(ctx)
+	})
+	return cachedBlocklist, blocklistErr
+}
+
+func fetchBlocklistFromRemote(ctx context.Context) (*Blocklist, error) {
 	// Open git repo
 	repo, err := git.OpenGitRepo(ctx, ".")
 	if err != nil {

--- a/pkg/config/imageVersion.go
+++ b/pkg/config/imageVersion.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"github.com/rancher/charts-build-scripts/pkg/git"
 	"github.com/rancher/charts-build-scripts/pkg/path"
@@ -18,7 +19,20 @@ type ImageConfig struct {
 	Tag        string `yaml:"tag,omitempty"` // optional
 }
 
+var (
+	cachedImageVersionList *ImageVersionCheckOptions
+	imageVersionOnce       sync.Once
+	imageVersionErr        error
+)
+
 func LoadImageVersionList(ctx context.Context) (*ImageVersionCheckOptions, error) {
+	imageVersionOnce.Do(func() {
+		cachedImageVersionList, imageVersionErr = fetchImageVersionListFromRemote(ctx)
+	})
+	return cachedImageVersionList, imageVersionErr
+}
+
+func fetchImageVersionListFromRemote(ctx context.Context) (*ImageVersionCheckOptions, error) {
 	// Open git repo
 	repo, err := git.OpenGitRepo(ctx, ".")
 	if err != nil {

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -463,8 +463,6 @@ func compareTars(ctx context.Context, leftFile, rightFile io.Reader) (bool, erro
 			identical = false
 		default:
 			// Deep compare tars
-			logger.Log(ctx, slog.LevelDebug, "deep compare contents of tar file", slog.String("filename", filename))
-
 			matches, err := compareTars(ctx, tars[0], tars[1])
 			if err != nil {
 				return false, fmt.Errorf("could not compare contents of %s: %s", filename, err)
@@ -492,8 +490,6 @@ func compareTars(ctx context.Context, leftFile, rightFile io.Reader) (bool, erro
 			identical = false
 		default:
 			// Deep compare tars
-			logger.Log(ctx, slog.LevelDebug, "deep compare contents of tgz file", slog.String("filename", filename))
-
 			matches, err := compareTgzs(ctx, tgzs[0], tgzs[1])
 			if err != nil {
 				return false, fmt.Errorf("could not compare contents of %s: %s", filename, err)

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -266,7 +266,6 @@ func (g *Git) IsClean(ctx context.Context) error {
 // StatusProcelain checks if the git repository is clean and,
 // returns true if it is clean, false otherwise
 func (g *Git) StatusProcelain(ctx context.Context) (bool, error) {
-	logger.Log(ctx, slog.LevelDebug, "check if git is clean")
 
 	cmd := exec.Command("git", "-C", g.Dir, "status", "--porcelain")
 

--- a/pkg/helm/export.go
+++ b/pkg/helm/export.go
@@ -79,7 +79,6 @@ func ExportHelmChart(ctx context.Context, rootFs, fs billy.Filesystem, helmChart
 		return err
 	}
 
-	logger.Log(ctx, slog.LevelInfo, "exported chart", slog.String("chartChartsDirPath", chartChartsDirpath), slog.String("tgzPath", tgzPath))
 	return nil
 }
 
@@ -209,9 +208,7 @@ func GenerateArchive(ctx context.Context, rootFs, fs billy.Filesystem, helmChart
 	}
 	if shouldUpdateArchive {
 		filesystem.CopyFile(ctx, rootFs, tempTgzPath, tgzPath)
-		logger.Log(ctx, slog.LevelInfo, "generated archive", slog.String("tgzPath", tgzPath))
-	} else {
-		logger.Log(ctx, slog.LevelInfo, "archive is up-to-date", slog.String("tgzPath", tgzPath))
 	}
+
 	return tgzPath, nil
 }

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -195,6 +195,9 @@ func applyBlocklist(ctx context.Context, index *helmRepo.IndexFile) error {
 	for chartName, chartVersions := range index.Entries {
 		for i, chartVersion := range chartVersions {
 			if blocklist.IsBlocked(chartName, chartVersion.Version) {
+				if chartVersion.Annotations != nil && chartVersion.Annotations["catalog.cattle.io/hidden"] == "true" {
+					continue // Already marked, skip
+				}
 				// Inject hidden annotation
 				if chartVersion.Annotations == nil {
 					chartVersion.Annotations = make(map[string]string)
@@ -203,10 +206,6 @@ func applyBlocklist(ctx context.Context, index *helmRepo.IndexFile) error {
 
 				// Update entry in place
 				index.Entries[chartName][i] = chartVersion
-
-				logger.Log(ctx, slog.LevelInfo, "marked chart as hidden",
-					slog.String("chart", chartName),
-					slog.String("version", chartVersion.Version))
 			}
 		}
 	}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -92,7 +92,6 @@ func CreateOrUpdateHelmIndex(ctx context.Context, rootFs billy.Filesystem) error
 // Returns an error if any version contains an invalid prerelease identifier
 func CheckVersionStandards(ctx context.Context, new *helmRepo.IndexFile) error {
 	allowedPrereleases := []string{"-alpha.", "-beta.", "-rc", "-rancher", "-security"}
-	logger.Log(ctx, slog.LevelInfo, "checking version standards", slog.Any("allowed", allowedPrereleases))
 
 	for chartName, chartVersions := range new.Entries {
 		for _, chartVersion := range chartVersions {
@@ -170,8 +169,6 @@ func updateIndex(ctx context.Context, original, new *helmRepo.IndexFile) *helmRe
 			// Try to preserve it only if nothing has changed.
 			if originalEntry.Digest == entry.Digest {
 				new.Entries[chart][i].Created = originalEntry.Created // Don't modify created timestamp
-			} else {
-				logger.Log(ctx, slog.LevelDebug, "chart was modified", slog.String("chart", chart), slog.String("version", version))
 			}
 		}
 	}

--- a/pkg/helm/metadata.go
+++ b/pkg/helm/metadata.go
@@ -2,14 +2,13 @@ package helm
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
-	"github.com/rancher/charts-build-scripts/pkg/logger"
 	"sigs.k8s.io/yaml"
 
 	helmChart "helm.sh/helm/v3/pkg/chart"
@@ -19,23 +18,20 @@ import (
 
 // GetHelmMetadataVersion gets the version of a Helm chart as defined in its Chart.yaml
 func GetHelmMetadataVersion(ctx context.Context, fs billy.Filesystem, mainHelmChartPath string) (string, error) {
-	logger.Log(ctx, slog.LevelInfo, "get helm metadata version")
 	chart, err := helmLoader.Load(filesystem.GetAbsPath(fs, mainHelmChartPath))
 	if err != nil {
-		return "", err
+		return "", errors.New("failed to load helm metadata: " + err.Error())
 	}
 
-	logger.Log(ctx, slog.LevelDebug, "metadata", slog.String("version", chart.Metadata.Version))
 	return chart.Metadata.Version, nil
 }
 
 // UpdateHelmMetadataWithName updates the name of the chart in the metadata
 func UpdateHelmMetadataWithName(ctx context.Context, fs billy.Filesystem, mainHelmChartPath string, name string) error {
-	logger.Log(ctx, slog.LevelInfo, "update helm metadata with name", slog.String("name", name))
 	// Check if Helm chart is valid
 	chart, err := helmLoader.Load(filesystem.GetAbsPath(fs, mainHelmChartPath))
 	if err != nil {
-		return err
+		return errors.New("helm chart not valid: " + err.Error())
 	}
 	chart.Metadata.Name = name
 	// Write to either the Chart.yaml or the requirements.yaml, depending on the version
@@ -59,7 +55,6 @@ func UpdateHelmMetadataWithName(ctx context.Context, fs billy.Filesystem, mainHe
 // ConvertToHelmChart converts a given path to a Helm chart.
 // It does so by moving all YAML files to templates and creating a dummy Chart.yaml and values.yaml
 func ConvertToHelmChart(ctx context.Context, fs billy.Filesystem, dirPath string) error {
-	logger.Log(ctx, slog.LevelInfo, "convert helm chart")
 
 	// Check if the Chart.yaml already exists, indicating this is a Helm chart already
 	chartYamlPath := filepath.Join(dirPath, "Chart.yaml")
@@ -83,7 +78,6 @@ func ConvertToHelmChart(ctx context.Context, fs billy.Filesystem, dirPath string
 
 	// Move all .yaml files to templates directory
 	moveYamlToTemplates := func(ctx context.Context, fs billy.Filesystem, path string, isDir bool) error {
-		logger.Log(ctx, slog.LevelDebug, "moving YAML files to templates", slog.String("path", path))
 
 		if isDir {
 			// skip creating directories since we will create them when we copy the file anyways
@@ -96,14 +90,13 @@ func ConvertToHelmChart(ctx context.Context, fs billy.Filesystem, dirPath string
 		// destPath should be the path to chart + templates + whatever path the original path of the file was within the chart
 		dirPathWithinChart, err := filesystem.MovePath(ctx, filepath.Dir(path), dirPath, "")
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to move path at %s with error: %w", dirPath, err)
 		}
 		destPath, err := filesystem.MovePath(ctx, path, dirPath, filepath.Join(dirPath, "templates", dirPathWithinChart))
 		if err != nil {
-			return err
+			return errors.New("failed to move path for templates with error: " + err.Error())
 		}
 
-		logger.Log(ctx, slog.LevelDebug, "moving", slog.String("from", path), slog.String("to", destPath))
 		return fs.Rename(path, destPath)
 	}
 
@@ -121,7 +114,6 @@ func ConvertToHelmChart(ctx context.Context, fs billy.Filesystem, dirPath string
 		APIVersion:  helmChart.APIVersionV2,
 	}
 
-	logger.Log(ctx, slog.LevelInfo, "initializing helm chart", slog.String("path", chartYamlPath))
 	return helmChartUtil.SaveChartfile(filesystem.GetAbsPath(fs, chartYamlPath), chartMetadata)
 }
 
@@ -129,7 +121,6 @@ func ConvertToHelmChart(ctx context.Context, fs billy.Filesystem, dirPath string
 func StandardizeChartYaml(ctx context.Context, fs billy.Filesystem, dirPath string) error {
 	chartYamlPath := filepath.Join(dirPath, "Chart.yaml")
 	absChartYamlPath := filesystem.GetAbsPath(fs, chartYamlPath)
-	logger.Log(ctx, slog.LevelInfo, "standardize helm chart", slog.String("path", absChartYamlPath))
 
 	chartMetadata, err := helmChartUtil.LoadChartfile(absChartYamlPath)
 	if err != nil {

--- a/pkg/helm/standardize.go
+++ b/pkg/helm/standardize.go
@@ -48,20 +48,16 @@ func standardizeAssetsFromCharts(ctx context.Context, repoFs billy.Filesystem) e
 		}
 		return nil
 	}
-	// Collect all charts from charts directory
-	logger.Log(ctx, slog.LevelInfo, "collecting valid charts", slog.String("RepositoryChartsDir", path.RepositoryChartsDir))
 
 	if err := filesystem.WalkDir(ctx, repoFs, path.RepositoryChartsDir, collectAllValidCharts); err != nil {
 		return fmt.Errorf("encountered error while trying to find Helm charts in repository: %s", err)
 	}
 	// Ensure you do not collect subcharts defined within charts
-	logger.Log(ctx, slog.LevelInfo, "removing collected subcharts")
 	for chartPath := range targetChartPaths {
 		chartPathDir := chartPath
 		for {
 			chartPathDir = filepath.Dir(chartPathDir)
 			if chartPathDir == "." {
-				logger.Log(ctx, slog.LevelDebug, "identified chart", slog.String("chartPath", chartPath))
 				break
 			}
 			_, ok := targetChartPaths[chartPathDir]
@@ -73,7 +69,6 @@ func standardizeAssetsFromCharts(ctx context.Context, repoFs billy.Filesystem) e
 		}
 	}
 	// Ensure that charts names + versions are unique
-	logger.Log(ctx, slog.LevelInfo, "ensuring chart versions are unique")
 	targetChartsVersions := make(map[string]string)
 	for chartPath, chart := range targetChartPaths {
 		chartVersion := fmt.Sprintf("%s-%s", chart.Metadata.Name, chart.Metadata.Version)

--- a/pkg/helm/zip.go
+++ b/pkg/helm/zip.go
@@ -3,13 +3,11 @@ package helm
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"path/filepath"
 	"strings"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
-	"github.com/rancher/charts-build-scripts/pkg/logger"
 	"github.com/rancher/charts-build-scripts/pkg/path"
 
 	helmLoader "helm.sh/helm/v3/pkg/chart/loader"
@@ -87,15 +85,12 @@ func DumpAssets(ctx context.Context, repoRoot string, specificAsset string) erro
 			}
 		}
 
-		// Unarchive Tgz file
-		logger.Log(ctx, slog.LevelInfo, "unarchiving", slog.String("tgzPath", tgzPath))
-
 		// Get path to unarchive tgz to
 		foundAsset = true
 		absAssetPath := filesystem.GetAbsPath(fs, tgzPath)
 		chart, err := helmLoader.Load(absAssetPath)
 		if err != nil {
-			return fmt.Errorf("could not load Helm chart: %s", err)
+			return fmt.Errorf("could not load Helm chart:%s error: %w", tgzPath, err)
 		}
 		// Unarchive tgz
 		chartChartsDirpath := filepath.Join(path.RepositoryChartsDir, chart.Metadata.Name, chart.Metadata.Version)
@@ -109,7 +104,6 @@ func DumpAssets(ctx context.Context, repoRoot string, specificAsset string) erro
 			return err
 		}
 
-		logger.Log(ctx, slog.LevelInfo, "generated chart", slog.String("chartChartsDirpath", chartChartsDirpath))
 		return nil
 	}
 

--- a/pkg/puller/archive.go
+++ b/pkg/puller/archive.go
@@ -3,12 +3,10 @@ package puller
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
-	"github.com/rancher/charts-build-scripts/pkg/logger"
 	"github.com/rancher/charts-build-scripts/pkg/options"
 )
 
@@ -24,7 +22,6 @@ type Archive struct {
 
 // Pull grabs the archive
 func (u Archive) Pull(ctx context.Context, rootFs, fs billy.Filesystem, path string) error {
-	logger.Log(ctx, slog.LevelInfo, "pulling from upstream", slog.String("URL", u.URL), slog.String("path", path))
 
 	if err := filesystem.GetChartArchive(fs, u.URL, chartArchiveFilepath); err != nil {
 		return err

--- a/pkg/puller/cache.go
+++ b/pkg/puller/cache.go
@@ -3,12 +3,10 @@ package puller
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
-	"github.com/rancher/charts-build-scripts/pkg/logger"
 )
 
 // RootCache is the cache at the root of the repository
@@ -20,7 +18,6 @@ func InitRootCache(ctx context.Context, repoRoot string, cacheMode bool, path st
 		return nil
 	}
 
-	logger.Log(ctx, slog.LevelInfo, "setting up cache", slog.String("path", path))
 	// Get repository filesystem
 	rootFs := filesystem.GetFilesystem(repoRoot)
 

--- a/pkg/puller/gitrepository.go
+++ b/pkg/puller/gitrepository.go
@@ -89,7 +89,6 @@ func (r GithubRepository) GetSSHURL() string {
 func (r GithubRepository) Pull(ctx context.Context, rootFs, fs billy.Filesystem, path string) error {
 	cloneURL := r.GetHTTPSURL()
 	isCacheable := r.IsCacheable()
-	logger.Log(ctx, slog.LevelInfo, "pulling from upstream", slog.String("url", cloneURL), slog.Bool("isCacheable", isCacheable))
 
 	if isCacheable {
 		pulledFromCache, err := RootCache.Get(ctx, r.CacheKey(), fs, path)
@@ -97,7 +96,6 @@ func (r GithubRepository) Pull(ctx context.Context, rootFs, fs billy.Filesystem,
 			return err
 		}
 		if pulledFromCache {
-			logger.Log(ctx, slog.LevelInfo, "pulled from cache", slog.String("repo", r.name), slog.String("path", path))
 			return nil
 		}
 	}

--- a/pkg/puller/oci.go
+++ b/pkg/puller/oci.go
@@ -2,12 +2,10 @@ package puller
 
 import (
 	"context"
-	"log/slog"
 	"os"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/rancher/charts-build-scripts/pkg/filesystem"
-	"github.com/rancher/charts-build-scripts/pkg/logger"
 	"github.com/rancher/charts-build-scripts/pkg/options"
 	helmGetter "helm.sh/helm/v3/pkg/getter"
 )
@@ -19,7 +17,6 @@ type Registry struct {
 
 // Pull pulls the chart from the registry into the filesystem
 func (r Registry) Pull(ctx context.Context, rootFs, fs billy.Filesystem, path string) error {
-	logger.Log(ctx, slog.LevelInfo, "pulling from upstream", slog.String("URL", r.URL), slog.String("path", path))
 
 	getter, err := helmGetter.NewOCIGetter()
 	if err != nil {

--- a/pkg/registries/assets.go
+++ b/pkg/registries/assets.go
@@ -19,8 +19,6 @@ import (
 //
 // this function is mocked for unit-testing
 var createAssetValuesRepoTagMap = func(ctx context.Context) (map[string][]string, error) {
-	logger.Log(ctx, slog.LevelInfo, "map all repository and tags from all values.yaml files on assets/<*>/<*>.tgz files")
-
 	repoTagMap := make(map[string][]string)
 
 	// iterate all folders inside assets/ dir
@@ -40,13 +38,10 @@ var createAssetValuesRepoTagMap = func(ctx context.Context) (map[string][]string
 	assetsTgzs = filterBlocklistedAssets(ctx, assetsTgzs, blocklist)
 
 	// decode .tgz values.yaml files into-memory
-	logger.Log(ctx, slog.LevelInfo, "decoding .tgz(values.yaml) in-memory")
 	valuesYamlsMap, err := filesystem.DecodeTgzValuesYamlMap(ctx, assetsTgzs)
 	if err != nil {
 		return nil, err
 	}
-
-	logger.Log(ctx, slog.LevelInfo, "", slog.Any("chartsToIgnoreTags", chartsToIgnoreTags))
 
 	// iterate through each values.yaml file and traverse through all fields looking for
 	// every value of a 'repository' and 'tag' field.


### PR DESCRIPTION
Issue: https://github.com/rancher/ecm-distro-tools/issues/1069

## Solution

Implemented singleton pattern using `sync.Once`:
- Config fetched once per process
- Cached in memory for process lifetime
- Thread-safe concurrent access
- Reduces git remote calls from N to 1


## Impact

- **Before:** 50+ packages × 4 ops = 200+ git remote calls per validate
- **After:** 2 git remote calls total (1 blocklist + 1 image-version)
- CI: Fresh process each run → always gets latest config
- Dev: Restart process to pick up config changes (rare)